### PR TITLE
feat: 쿠폰 정책 삭제 기능 구현(KAN-27)

### DIFF
--- a/client/coupon/src/main/java/com/live_commerce/coupon/application/exception/CouponExceptionCode.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/application/exception/CouponExceptionCode.java
@@ -14,8 +14,8 @@ public enum CouponExceptionCode implements ExceptionCode {
   DUPLICATE_COUPON_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 쿠폰명입니다."),
   INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, "시작일은 종료일보다 이전이어야 합니다."),
   DISCOUNT_GREATER_THAN_MAX_ORDER_AMOUNT(HttpStatus.BAD_REQUEST, "할인 금액이 최대 주문 금액을 초과할 수 없습니다."),
-  DISCOUNT_GREATER_THAN_100(HttpStatus.BAD_REQUEST, "정률 할인 비율은 100을 넘을 수 없습니다.");
-
+  DISCOUNT_GREATER_THAN_100(HttpStatus.BAD_REQUEST, "정률 할인 비율은 100을 넘을 수 없습니다."),
+  COUPON_POLICY_NOT_FOUND(HttpStatus.NOT_FOUND, "쿠폰 정책이 없거나 모두 삭제되었습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/client/coupon/src/main/java/com/live_commerce/coupon/application/service/CouponPolicyService.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/application/service/CouponPolicyService.java
@@ -63,4 +63,14 @@ public class CouponPolicyService {
         .map(ReadCouponPolicyResponse::fromCouponPolicy)
         .collect(Collectors.toList());
   }
+
+  public void deleteCouponPolicy(UUID id) {
+    CouponPolicy couponPolicy = couponRepository.findById(id)
+        .orElseThrow(() -> {
+          CouponPolicyException.forCouponPolicyNotFound();
+          return null;
+        });
+    couponPolicy.markCouponAsDeleted(couponPolicy.getName());
+    couponRepository.save(couponPolicy);
+  }
 }

--- a/client/coupon/src/main/java/com/live_commerce/coupon/application/service/CouponPolicyService.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/application/service/CouponPolicyService.java
@@ -10,6 +10,8 @@ import com.live_commerce.coupon.presentation.dto.response.CreateCouponPolicyResp
 import com.live_commerce.coupon.presentation.dto.response.ReadCouponPolicyResponse;
 import java.math.BigDecimal;
 import java.util.UUID;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -52,4 +54,10 @@ public class CouponPolicyService {
     return ReadCouponPolicyResponse.fromCouponPolicy(couponPolicy);
   }
 
+  public List<ReadCouponPolicyResponse> getCouponPolicies() {
+    List<CouponPolicy> couponPolicyList = couponRepository.findByDeletedStatusFalse();
+    return couponPolicyList.stream()
+        .map(ReadCouponPolicyResponse::fromCouponPolicy)
+        .collect(Collectors.toList());
+  }
 }

--- a/client/coupon/src/main/java/com/live_commerce/coupon/application/service/CouponPolicyService.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/application/service/CouponPolicyService.java
@@ -50,7 +50,10 @@ public class CouponPolicyService {
 
   public ReadCouponPolicyResponse getCouponPolicy(UUID id) {
     CouponPolicy couponPolicy = couponRepository.findByCodeAndDeletedStatusFalse(id)
-        .orElseThrow(() -> new CouponPolicyException(CouponExceptionCode.COUPON_POLICY_NOT_FOUND));
+        .orElseThrow(() -> {
+          CouponPolicyException.forCouponPolicyNotFound();
+          return null;
+        });
     return ReadCouponPolicyResponse.fromCouponPolicy(couponPolicy);
   }
 

--- a/client/coupon/src/main/java/com/live_commerce/coupon/application/service/CouponPolicyService.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/application/service/CouponPolicyService.java
@@ -1,6 +1,5 @@
 package com.live_commerce.coupon.application.service;
 
-import com.live_commerce.coupon.application.exception.CouponExceptionCode;
 import com.live_commerce.coupon.domain.exception.CouponPolicyException;
 import com.live_commerce.coupon.domain.model.CouponPolicy;
 import com.live_commerce.coupon.domain.model.DISCOUNT_TYPE;

--- a/client/coupon/src/main/java/com/live_commerce/coupon/application/service/CouponPolicyService.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/application/service/CouponPolicyService.java
@@ -1,12 +1,15 @@
 package com.live_commerce.coupon.application.service;
 
+import com.live_commerce.coupon.application.exception.CouponExceptionCode;
 import com.live_commerce.coupon.domain.exception.CouponPolicyException;
 import com.live_commerce.coupon.domain.model.CouponPolicy;
 import com.live_commerce.coupon.domain.model.DISCOUNT_TYPE;
 import com.live_commerce.coupon.domain.repository.CouponPolicyRepository;
 import com.live_commerce.coupon.presentation.dto.request.CreateCouponPolicyRequest;
 import com.live_commerce.coupon.presentation.dto.response.CreateCouponPolicyResponse;
+import com.live_commerce.coupon.presentation.dto.response.ReadCouponPolicyResponse;
 import java.math.BigDecimal;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,4 +45,11 @@ public class CouponPolicyService {
     couponRepository.save(couponPolicy);
     return CreateCouponPolicyResponse.fromCouponPolicy(couponPolicy);
   }
+
+  public ReadCouponPolicyResponse getCouponPolicy(UUID id) {
+    CouponPolicy couponPolicy = couponRepository.findByCodeAndDeletedStatusFalse(id)
+        .orElseThrow(() -> new CouponPolicyException(CouponExceptionCode.COUPON_POLICY_NOT_FOUND));
+    return ReadCouponPolicyResponse.fromCouponPolicy(couponPolicy);
+  }
+
 }

--- a/client/coupon/src/main/java/com/live_commerce/coupon/domain/exception/CouponPolicyException.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/domain/exception/CouponPolicyException.java
@@ -27,4 +27,9 @@ public class CouponPolicyException extends CustomException {
         CouponExceptionCode.DISCOUNT_GREATER_THAN_100
     );
   }
+
+  public static void forCouponPolicyNotFound(){
+    throw new CouponPolicyException(CouponExceptionCode.COUPON_POLICY_NOT_FOUND);
+  }
+
 }

--- a/client/coupon/src/main/java/com/live_commerce/coupon/domain/model/BaseEntity.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/domain/model/BaseEntity.java
@@ -31,7 +31,7 @@ public abstract class BaseEntity {
 
   private LocalDateTime deletedAt;
 
-  private boolean deletedStatus;
+  private Boolean deletedStatus = false;
 
   public void markAsDeleted(String deletedBy){
     if(this.deletedStatus){

--- a/client/coupon/src/main/java/com/live_commerce/coupon/domain/model/BaseEntity.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/domain/model/BaseEntity.java
@@ -32,4 +32,13 @@ public abstract class BaseEntity {
   private LocalDateTime deletedAt;
 
   private boolean deletedStatus;
+
+  public void markAsDeleted(String deletedBy){
+    if(this.deletedStatus){
+      throw new IllegalStateException("Already deleted");
+    }
+    this.deletedStatus = true;
+    this.deletedBy = deletedBy;
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/client/coupon/src/main/java/com/live_commerce/coupon/domain/model/CouponPolicy.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/domain/model/CouponPolicy.java
@@ -72,4 +72,8 @@ public class CouponPolicy extends BaseEntity {
 
   }
 
+  public void markCouponAsDeleted(String deletedBy){
+    markAsDeleted(deletedBy);
+  }
+
 }

--- a/client/coupon/src/main/java/com/live_commerce/coupon/domain/repository/CouponPolicyRepository.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/domain/repository/CouponPolicyRepository.java
@@ -1,8 +1,7 @@
 package com.live_commerce.coupon.domain.repository;
 
 import com.live_commerce.coupon.domain.model.CouponPolicy;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CouponPolicyRepository extends JpaRepository<CouponPolicy, UUID> {
@@ -10,4 +9,6 @@ public interface CouponPolicyRepository extends JpaRepository<CouponPolicy, UUID
   Boolean existsByName(String name);
 
   Optional<CouponPolicy> findByCodeAndDeletedStatusFalse(UUID id);
+
+  List<CouponPolicy> findByDeletedStatusFalse();
 }

--- a/client/coupon/src/main/java/com/live_commerce/coupon/domain/repository/CouponPolicyRepository.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/domain/repository/CouponPolicyRepository.java
@@ -1,10 +1,13 @@
 package com.live_commerce.coupon.domain.repository;
 
 import com.live_commerce.coupon.domain.model.CouponPolicy;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CouponPolicyRepository extends JpaRepository<CouponPolicy, UUID> {
 
   Boolean existsByName(String name);
+
+  Optional<CouponPolicy> findByCodeAndDeletedStatusFalse(UUID id);
 }

--- a/client/coupon/src/main/java/com/live_commerce/coupon/presentation/controller/CouponPolicyController.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/presentation/controller/CouponPolicyController.java
@@ -39,7 +39,7 @@ public class CouponPolicyController {
     return ResponseUtil.success(response);
   }
 
-  @PatchMapping("/{id}")
+  @DeleteMapping("/{id}")
   public ResponseEntity<ApiResponse<Void>> deleteCouponPolicy(@PathVariable UUID id){
     couponService.deleteCouponPolicy(id);
     return ResponseUtil.noContent();

--- a/client/coupon/src/main/java/com/live_commerce/coupon/presentation/controller/CouponPolicyController.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/presentation/controller/CouponPolicyController.java
@@ -5,7 +5,9 @@ import com.live_commerce.coupon.infrastructure.common.ResponseUtil;
 import com.live_commerce.coupon.presentation.common.ApiResponse;
 import com.live_commerce.coupon.presentation.dto.request.CreateCouponPolicyRequest;
 import com.live_commerce.coupon.presentation.dto.response.CreateCouponPolicyResponse;
+import com.live_commerce.coupon.presentation.dto.response.ReadCouponPolicyResponse;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,4 +25,12 @@ public class CouponPolicyController {
     CreateCouponPolicyResponse response = couponService.createCouponPolicy(request);
     return ResponseUtil.success(response);
   }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResponse<ReadCouponPolicyResponse>> getCouponPolicy(@PathVariable("id") UUID id){
+    ReadCouponPolicyResponse response = couponService.getCouponPolicy(id);
+    return ResponseUtil.success(response);
+  }
+
+
 }

--- a/client/coupon/src/main/java/com/live_commerce/coupon/presentation/controller/CouponPolicyController.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/presentation/controller/CouponPolicyController.java
@@ -39,5 +39,11 @@ public class CouponPolicyController {
     return ResponseUtil.success(response);
   }
 
+  @PatchMapping("/{id}")
+  public ResponseEntity<ApiResponse<Void>> deleteCouponPolicy(@PathVariable UUID id){
+    couponService.deleteCouponPolicy(id);
+    return ResponseUtil.noContent();
+  }
+
 
 }

--- a/client/coupon/src/main/java/com/live_commerce/coupon/presentation/controller/CouponPolicyController.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/presentation/controller/CouponPolicyController.java
@@ -8,6 +8,7 @@ import com.live_commerce.coupon.presentation.dto.response.CreateCouponPolicyResp
 import com.live_commerce.coupon.presentation.dto.response.ReadCouponPolicyResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -29,6 +30,12 @@ public class CouponPolicyController {
   @GetMapping("/{id}")
   public ResponseEntity<ApiResponse<ReadCouponPolicyResponse>> getCouponPolicy(@PathVariable("id") UUID id){
     ReadCouponPolicyResponse response = couponService.getCouponPolicy(id);
+    return ResponseUtil.success(response);
+  }
+
+  @GetMapping("/")
+  public ResponseEntity<ApiResponse<List<ReadCouponPolicyResponse>>> getCouponPolicies(){
+    List<ReadCouponPolicyResponse> response = couponService.getCouponPolicies();
     return ResponseUtil.success(response);
   }
 

--- a/client/coupon/src/main/java/com/live_commerce/coupon/presentation/dto/response/ReadCouponPolicyResponse.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/presentation/dto/response/ReadCouponPolicyResponse.java
@@ -1,0 +1,31 @@
+package com.live_commerce.coupon.presentation.dto.response;
+
+import com.live_commerce.coupon.domain.model.CouponPolicy;
+import java.util.UUID;
+
+public record ReadCouponPolicyResponse(
+    UUID id,
+    String name,
+    String discountType,
+    String discountValue,
+    String minOrderAmt,
+    String maxOrderAmt,
+    String startAt,
+    String endAt,
+    boolean isActive
+) {
+
+  public static ReadCouponPolicyResponse fromCouponPolicy(CouponPolicy couponPolicy) {
+    return new ReadCouponPolicyResponse(
+        couponPolicy.getCode(),
+        couponPolicy.getName(),
+        couponPolicy.getDiscountType().name(),
+        couponPolicy.getDiscountValue().toString(),
+        couponPolicy.getMinOrderAmt().toString(),
+        couponPolicy.getMaxOrderAmt() != null ? couponPolicy.getMaxOrderAmt().toString() : null,
+        couponPolicy.getStartAt().toString(),
+        couponPolicy.getEndAt().toString(),
+        couponPolicy.isActive()
+    );
+  }
+}

--- a/client/coupon/src/test/java/com/live_commerce/coupon/application/service/CouponPolicyServiceTest.java
+++ b/client/coupon/src/test/java/com/live_commerce/coupon/application/service/CouponPolicyServiceTest.java
@@ -56,7 +56,7 @@ public class CouponPolicyServiceTest {
         .maxOrderAmt(BigDecimal.valueOf(1000))
         .startAt(LocalDateTime.now().plusDays(1))
         .endAt(LocalDateTime.now().plusDays(30))
-        .isActive(false)
+        .isActive(true)
         .build();
 
   }
@@ -158,4 +158,33 @@ public class CouponPolicyServiceTest {
     verify(couponPolicyRepository, times(1)).findByCodeAndDeletedStatusFalse(invalidCouponId);
 
   }
+
+  @Test
+  @DisplayName("쿠폰 정책 삭제 시 소프트 delete 적용 확인")
+  void deleteCouponPolicySoftDelete() {
+    // given
+    UUID validCouponId = couponPolicy.getCode();
+
+    // when
+    when(couponPolicyRepository.findById(validCouponId))
+        .thenReturn(Optional.of(couponPolicy));
+
+    couponPolicyService.deleteCouponPolicy(validCouponId);
+
+    // then
+    assertThat(couponPolicy.getDeletedStatus()).isTrue();
+    assertThat(couponPolicy.getDeletedBy()).isNotNull();
+    assertThat(couponPolicy.getDeletedAt()).isNotNull();
+
+    when(couponPolicyRepository.findById(validCouponId))
+        .thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> couponPolicyService.getCouponPolicy(validCouponId))
+        .isInstanceOf(CouponPolicyException.class)
+        .hasMessageContaining("쿠폰 정책이 없거나 모두 삭제되었습니다.");
+
+    verify(couponPolicyRepository, times(1)).save(couponPolicy);
+  }
+
+
 }

--- a/client/coupon/src/test/java/com/live_commerce/coupon/application/service/CouponPolicyServiceTest.java
+++ b/client/coupon/src/test/java/com/live_commerce/coupon/application/service/CouponPolicyServiceTest.java
@@ -1,13 +1,21 @@
 package com.live_commerce.coupon.application.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.live_commerce.coupon.domain.exception.CouponPolicyException;
+import com.live_commerce.coupon.domain.model.CouponPolicy;
 import com.live_commerce.coupon.domain.model.DISCOUNT_TYPE;
 import com.live_commerce.coupon.domain.repository.CouponPolicyRepository;
 import com.live_commerce.coupon.presentation.dto.request.CreateCouponPolicyRequest;
+import com.live_commerce.coupon.presentation.dto.response.ReadCouponPolicyResponse;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.*;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -24,6 +32,8 @@ public class CouponPolicyServiceTest {
 
   private CreateCouponPolicyRequest request;
 
+  private CouponPolicy couponPolicy;
+
   @BeforeEach
   void setUp() {
     request = new CreateCouponPolicyRequest(
@@ -36,6 +46,19 @@ public class CouponPolicyServiceTest {
         LocalDateTime.now().plusDays(30),
         true
     );
+
+    couponPolicy = CouponPolicy.builder()
+        .code(UUID.randomUUID())
+        .name("테스트 쿠폰")
+        .discountType(DISCOUNT_TYPE.FIXED)
+        .discountValue(BigDecimal.valueOf(100))
+        .minOrderAmt(BigDecimal.valueOf(500))
+        .maxOrderAmt(BigDecimal.valueOf(1000))
+        .startAt(LocalDateTime.now().plusDays(1))
+        .endAt(LocalDateTime.now().plusDays(30))
+        .isActive(false)
+        .build();
+
   }
 
   @Test
@@ -95,5 +118,44 @@ public class CouponPolicyServiceTest {
     assertThatThrownBy(() -> couponPolicyService.createCouponPolicy(request))
         .isInstanceOf(CouponPolicyException.class)
         .hasMessageContaining("정률 할인 비율은 100을 넘을 수 없습니다.");
+  }
+
+  @Test
+  @DisplayName("존재하는 쿠폰 정책 조회 성공")
+  void getCouponPolicySuccess() {
+    // given
+    UUID validCouponId = couponPolicy.getCode();
+
+    // when
+    when(couponPolicyRepository.findByCodeAndDeletedStatusFalse(validCouponId)).thenReturn(
+        Optional.of(couponPolicy));
+
+    ReadCouponPolicyResponse response = couponPolicyService.getCouponPolicy(validCouponId);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.id()).isEqualTo(validCouponId);
+    assertThat(response.name()).isEqualTo("테스트 쿠폰");
+    verify(couponPolicyRepository, times(1)).findByCodeAndDeletedStatusFalse(validCouponId);
+
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 쿠폰 정책 조회 시 예외 발생")
+  void getCouponPolicyNotFound() {
+    // given
+    UUID invalidCouponId = UUID.randomUUID();
+
+    // when
+    when(couponPolicyRepository.findByCodeAndDeletedStatusFalse(invalidCouponId)).thenReturn(
+        Optional.empty());
+
+    // then
+    assertThatThrownBy(() -> couponPolicyService.getCouponPolicy(invalidCouponId))
+        .isInstanceOf(CouponPolicyException.class)
+        .hasMessageContaining("쿠폰 정책이 없거나 모두 삭제되었습니다.");
+
+    verify(couponPolicyRepository, times(1)).findByCodeAndDeletedStatusFalse(invalidCouponId);
+
   }
 }

--- a/client/coupon/src/test/java/com/live_commerce/coupon/application/service/CouponPolicyServiceTest.java
+++ b/client/coupon/src/test/java/com/live_commerce/coupon/application/service/CouponPolicyServiceTest.java
@@ -71,7 +71,7 @@ public class CouponPolicyServiceTest {
         request.discountValue(),
         request.minOrderAmt(),
         request.maxOrderAmt(),
-        LocalDateTime.now().plusDays(10), // 시작일(startAt)이 종료일(endAt)보다 나중
+        LocalDateTime.now().plusDays(10),
         LocalDateTime.now().plusDays(5),
         request.isActive()
     );
@@ -89,7 +89,7 @@ public class CouponPolicyServiceTest {
     request = new CreateCouponPolicyRequest(
         request.name(),
         request.discountType(),
-        BigDecimal.valueOf(2000), // 할인 금액을 최대 주문 금액보다 크게 설정
+        BigDecimal.valueOf(2000),
         request.minOrderAmt(),
         BigDecimal.valueOf(500),
         request.startAt(),
@@ -106,8 +106,8 @@ public class CouponPolicyServiceTest {
   void throwExceptionForRateDiscountGreaterThan100() {
     request = new CreateCouponPolicyRequest(
         request.name(),
-        DISCOUNT_TYPE.RATE, // 할인 유형 RATE로 설정
-        BigDecimal.valueOf(110), // 할인율이 100을 초과
+        DISCOUNT_TYPE.RATE,
+        BigDecimal.valueOf(110),
         request.minOrderAmt(),
         request.maxOrderAmt(),
         request.startAt(),


### PR DESCRIPTION
## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [ ] 코드 작성 가이드라인을 준수했는가?
* [ ] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 쿠폰 정책 삭제 기능 구현 

* **세부 내용**
  * (설명을 여기에 작성)

## 💡 추가 설명

* 삭제 기능 구현 중, API 통일성을 위해 id로 받아온 후 내부에서 getName()을 사용하여 deletedBy를 대체하는 방식으로 결정했습니다. 다만, 이 방식이 최선인지는 모르겠습니다... 더 좋은 방법이 있다면 알려주시면 감사하겠습니다..!

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
![image](https://github.com/user-attachments/assets/98aa0727-6b83-438f-a389-dc5868aad863)
![image](https://github.com/user-attachments/assets/ae4f16cb-e879-464b-88bc-a3c4264f322a)
