### PR TITLE
feature: 회원가입 시 권한 기반 승인 처리 및 더미 데이터 추가 (KAN-39)

### DIFF
--- a/client/user/src/main/java/com/live_commerce/user/application/dto/auth/request/UserSignUpRequestDto.java
+++ b/client/user/src/main/java/com/live_commerce/user/application/dto/auth/request/UserSignUpRequestDto.java
@@ -31,17 +31,20 @@ public record UserSignUpRequestDto(
 
 	boolean alarmConsent,
 
-	UserRole userRole
+	UserRole userRole,
+
+	String masterKey // MASTER 가입 시 필수
 
 ) {
-	public User toEntity(String encodedPassword) {
+	public User toEntity(String encodedPassword, boolean approved) {
 		return User.of(
 			this.username,
 			encodedPassword,
 			this.email,
 			this.nickname,
 			this.alarmConsent,
-			this.userRole
+			this.userRole,
+			approved
 		);
 	}
 }

--- a/client/user/src/main/java/com/live_commerce/user/application/exception/UserExceptionCode.java
+++ b/client/user/src/main/java/com/live_commerce/user/application/exception/UserExceptionCode.java
@@ -22,7 +22,10 @@ public enum UserExceptionCode implements ExceptionCode {
     VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "인증번호가 만료되었습니다. 다시 시도해주세요."),
     INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
     MAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "메일 전송에 실패했습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다.");
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다."),
+    INVALID_MASTER_KEY(HttpStatus.UNAUTHORIZED, "마스터 등록 키가 유효하지 않습니다."),
+    UNAPPROVED_USER(HttpStatus.FORBIDDEN, "승인되지 않은 계정입니다.");
+
 
 
 

--- a/client/user/src/main/java/com/live_commerce/user/application/service/AuthService.java
+++ b/client/user/src/main/java/com/live_commerce/user/application/service/AuthService.java
@@ -14,6 +14,7 @@ import com.live_commerce.user.application.dto.auth.response.TokenReissueResponse
 import com.live_commerce.user.application.exception.CustomException;
 import com.live_commerce.user.application.exception.UserExceptionCode;
 import com.live_commerce.user.domain.model.User;
+import com.live_commerce.user.domain.model.UserRole;
 import com.live_commerce.user.domain.repository.UserRepository;
 import com.live_commerce.user.infrastructure.common.JwtUtil;
 import com.live_commerce.user.infrastructure.common.PasswordGenerator;
@@ -38,14 +39,37 @@ public class AuthService {
 	@Value("${service.jwt.refresh-expiration}")
 	private long refreshTokenExpirationMillis;
 
+	@Value("${user.master-key}")
+	private String masterKey;
+
+
 	@Transactional
 	public UserSignUpResponseDto signUp(UserSignUpRequestDto request) {
 		validateEmail(request.email());
+
+		// MASTER 권한은 등록 키가 필요
+		if (request.userRole() == UserRole.MASTER) {
+			validateMasterRegistrationKey(request.masterKey());
+		}
+
+		// SELLER, SHOW_HOST는 기본적으로 비승인 상태로 가입됨
+		boolean approved = switch (request.userRole()) {
+			case SELLER, SHOW_HOST -> false;
+			default -> true;
+		};
+
 		String encodedPassword = passwordEncoder.encode(request.password());
-		User user = request.toEntity(encodedPassword);
+		User user = request.toEntity(encodedPassword, approved);
 		User savedUser = userRepository.save(user);
 		return UserSignUpResponseDto.from(savedUser);
 	}
+
+	private void validateMasterRegistrationKey(String inputKey) {
+		if (!inputKey.equals(masterKey)) {
+			throw new CustomException(UserExceptionCode.INVALID_MASTER_KEY);
+		}
+	}
+
 
 	@Transactional
 	public UserSignInResponseDto signIn(UserSignInRequestDto requestDto) {
@@ -53,6 +77,11 @@ public class AuthService {
 			.filter(u -> passwordEncoder.matches(requestDto.password(), u.getPassword()))
 			.map(this::validateActiveUser)
 			.orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_CREDENTIALS));
+
+		// 승인 여부 체크
+		if (!user.isApproved()) {
+			throw new CustomException(UserExceptionCode.UNAPPROVED_USER);
+		}
 
 		UUID userId = user.getUserId();
 		String accessToken = jwtUtil.createAccessToken(userId, user.getUsername(), user.getUserRole());
@@ -125,6 +154,15 @@ public class AuthService {
 		user.changePassword(encoded);
 		mailService.sendTemporaryPassword(email, tempPassword);
 	}
+
+	@Transactional
+	public void approveUser(UUID userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(UserExceptionCode.USER_NOT_FOUND));
+
+		user.approve();
+	}
+
 
 	private User findActiveUserByEmail(String email) {
 		return userRepository.findByEmail(email)

--- a/client/user/src/main/java/com/live_commerce/user/domain/model/User.java
+++ b/client/user/src/main/java/com/live_commerce/user/domain/model/User.java
@@ -23,7 +23,7 @@ public class User extends BaseEntity {
 	@UuidGenerator
 	private UUID userId;
 
-	@Column(nullable = false)
+	@Column(nullable = false, unique = true)
 	private String username; // 사용자 ID
 
 	@Column(nullable = false)
@@ -42,21 +42,25 @@ public class User extends BaseEntity {
 	@Column(nullable = false, length = 30)
 	private UserRole userRole; // 사용자 역할
 
+	@Column(nullable = false)
+	private boolean approved;
+
 	// 정적 팩토리 메서드
 	public static User of(String username, String password, String email, String nickname,
-		boolean alarmConsent, UserRole userRole) {
-		return new User(username, password, email, nickname, alarmConsent, userRole);
+		boolean alarmConsent, UserRole userRole, boolean approved) {
+		return new User(username, password, email, nickname, alarmConsent, userRole, approved);
 	}
 
 	// 프라이빗 생성자
 	private User(String username, String password, String email, String nickname,
-		boolean alarmConsent, UserRole userRole) {
+		boolean alarmConsent, UserRole userRole, boolean approved) {
 		this.username = username;
 		this.password = password;
 		this.email = email;
 		this.nickname = nickname;
 		this.alarmConsent = alarmConsent;
 		this.userRole = userRole;
+		this.approved = approved;
 	}
 
 	public void updateUser(String password, String email, String nickname, boolean alarmConsent, UserRole userRole) {
@@ -69,6 +73,14 @@ public class User extends BaseEntity {
 
 	public void changePassword(String newEncodedPassword) {
 		this.password = newEncodedPassword;
+	}
+
+	public boolean isApproved() {
+		return approved;
+	}
+
+	public void approve() {
+		this.approved = true;
 	}
 
 

--- a/client/user/src/main/java/com/live_commerce/user/infrastructure/filter/AuthenticationFilter.java
+++ b/client/user/src/main/java/com/live_commerce/user/infrastructure/filter/AuthenticationFilter.java
@@ -29,7 +29,9 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 		String requestUri = request.getRequestURI();
 
 		// 인증이 필요 없는 경로는 필터를 통과시킴
-		if ((requestUri.startsWith("/api/v1/auth/") && !requestUri.equals("/api/v1/auth/logout")) ||
+		if ((requestUri.startsWith("/api/v1/auth/") &&
+			!requestUri.startsWith("/api/v1/auth/approve") &&
+			!requestUri.equals("/api/v1/auth/logout")) ||
 			requestUri.startsWith("/swagger-ui/") ||
 			requestUri.startsWith("/v3/api-docs") ||
 			requestUri.startsWith("/actuator")) {

--- a/client/user/src/main/java/com/live_commerce/user/presentation/controller/AuthController.java
+++ b/client/user/src/main/java/com/live_commerce/user/presentation/controller/AuthController.java
@@ -1,7 +1,11 @@
 package com.live_commerce.user.presentation.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,7 +21,6 @@ import com.live_commerce.user.application.dto.auth.response.TokenReissueResponse
 import com.live_commerce.user.application.dto.auth.response.UserSignInResponseDto;
 import com.live_commerce.user.application.dto.auth.response.UserSignUpResponseDto;
 import com.live_commerce.user.application.service.AuthService;
-import com.live_commerce.user.application.service.MailService;
 import com.live_commerce.user.infrastructure.common.ResponseUtil;
 import com.live_commerce.user.infrastructure.security.RequestUserDetails;
 import com.live_commerce.user.presentation.common.ApiResponse;
@@ -85,4 +88,12 @@ public class AuthController {
 		TokenReissueResponseDto response = authService.reissueToken(request.refreshToken());
 		return ResponseUtil.success(response);
 	}
+
+	@PostMapping("/approve/{userId}")
+	@PreAuthorize("hasRole('MASTER')")
+	public ResponseEntity<ApiResponse<String>> approveUser(@PathVariable UUID userId) {
+		authService.approveUser(userId);
+		return ResponseUtil.success("사용자가 승인되었습니다.");
+	}
+
 }

--- a/client/user/src/main/resources/db/create-user.sql
+++ b/client/user/src/main/resources/db/create-user.sql
@@ -1,0 +1,75 @@
+-- MASTER 계정
+INSERT INTO users.p_user (
+    user_id, username, password, email, nickname, alarm_consent, user_role, approved, created_at, updated_at, deleted_status
+)
+VALUES (
+           '00000000-0000-0000-0000-000000000001',
+           'master',
+           '$2a$10$ImHOQUPjwhosYCFjU0hUQO4SMx3NFds.sP5hlXOtFsjWtMJxK43Iu',
+           'master@example.com',
+           '마스터계정',
+           true,
+           'MASTER',
+           true,
+           now(),
+           now(),
+           false
+       )
+    ON CONFLICT (username) DO NOTHING;
+
+-- SELLER 계정
+INSERT INTO users.p_user (
+    user_id, username, password, email, nickname, alarm_consent, user_role, approved, created_at, updated_at, deleted_status
+)
+VALUES (
+           '00000000-0000-0000-0000-000000000002',
+           'seller',
+           '$2a$10$ImHOQUPjwhosYCFjU0hUQO4SMx3NFds.sP5hlXOtFsjWtMJxK43Iu',
+           'seller@example.com',
+           '판매자계정',
+           true,
+           'SELLER',
+           true,
+           now(),
+           now(),
+           false
+       )
+    ON CONFLICT (username) DO NOTHING;
+
+-- SHOW_HOST 계정
+INSERT INTO users.p_user (
+    user_id, username, password, email, nickname, alarm_consent, user_role, approved, created_at, updated_at, deleted_status
+)
+VALUES (
+           '00000000-0000-0000-0000-000000000003',
+           'showhost',
+           '$2a$10$ImHOQUPjwhosYCFjU0hUQO4SMx3NFds.sP5hlXOtFsjWtMJxK43Iu',
+           'showhost@example.com',
+           '쇼호스트계정',
+           true,
+           'SHOW_HOST',
+           true,
+           now(),
+           now(),
+           false
+       )
+    ON CONFLICT (username) DO NOTHING;
+
+-- CUSTOMER 계정
+INSERT INTO users.p_user (
+    user_id, username, password, email, nickname, alarm_consent, user_role, approved, created_at, updated_at, deleted_status
+)
+VALUES (
+           '00000000-0000-0000-0000-000000000004',
+           'customer',
+           '$2a$10$ImHOQUPjwhosYCFjU0hUQO4SMx3NFds.sP5hlXOtFsjWtMJxK43Iu',
+           'customer@example.com',
+           '일반사용자',
+           true,
+           'CUSTOMER',
+           true,
+           now(),
+           now(),
+           false
+       )
+    ON CONFLICT (username) DO NOTHING;

--- a/server/config/src/main/resources/config-repo/user-dev.yml
+++ b/server/config/src/main/resources/config-repo/user-dev.yml
@@ -7,7 +7,9 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
+    defer-datasource-initialization: true
+
     properties:
       hibernate:
         show_sql: true
@@ -19,6 +21,11 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
+
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:db/create-user.sql
 
   data:
     redis:
@@ -40,4 +47,8 @@ service:
     access-expiration: 3600000
     refresh-expiration: 10800000
     secret-key: ${JWT_SECRET_KEY}
+
+user:
+  master-key: ${MASTER_KEY}
+
 

--- a/server/gateway/src/main/java/com/live_commerce/gateway/filter/AuthenticationFilter.java
+++ b/server/gateway/src/main/java/com/live_commerce/gateway/filter/AuthenticationFilter.java
@@ -49,7 +49,8 @@ public class AuthenticationFilter implements GlobalFilter {
 
 	private boolean isPublicPath(String path) {
 		// /api/v1/auth/logout 은 인증 필요하므로 제외시킴
-		return !path.equals("/api/v1/auth/logout") && (
+		return !path.equals("/api/v1/auth/logout") &&
+			!path.startsWith("/api/v1/auth/approve") && (
 			path.startsWith("/api/v1/auth/") ||
 				path.startsWith("/swagger-ui/") ||
 				path.startsWith("/v3/api-docs/") ||


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 회원가입 시 권한 기반 승인 처리 및 더미 데이터 추가

* **세부 내용**
  * 회원 가입 시 권한에 따라 자동 승인 여부 분기
    * `CUSTOMER`, `MASTER` → 가입 즉시 승인
    * `SELLER`, `SHOW_HOST` → 가입 시 승인 대기
  * `MASTER` 권한은 별도의 등록 키(`master-key`) 입력 필요
  * 미승인 계정 로그인 시 차단 처리
  * 관리자가 특정 유저를 승인할 수 있는 `/api/v1/auth/approve/{userId}` API 추가 (MASTER 권한 필요)

## 💡 추가 설명

* 테스트용 더미 계정 데이터를 추가함
  * `username`은 `master`, `seller`, `showhost`, `customer` 로 설정되어 있고 비밀번호는 모두 동일하게 `Password123!` 으로 설정됨 (BCrypt로 암호화)
  * Postman 등으로 로그인 테스트할 때는 아래와 같이 사용 가능:
  ```json
  {
    "username": "master",
    "password": "Password123!"
  }
 
 * 더미 데이터는 `create-user.sql`을 통해 자동으로 삽입되며, 유저 서비스 실행 시 자동 반영됨

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
