### PR TITLE
refactor: 라이브방송 검색기능 구현 및 리팩토링 (KAN-41)

### DIFF
--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/request/BroadcastProductConnectDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/request/BroadcastProductConnectDto.java
@@ -3,7 +3,7 @@ package com.live_commerce.livebroadcast.application.dto.request;
 import java.util.UUID;
 
 public record BroadcastProductConnectDto(
-        UUID broadcastId,
+        UUID liveBroadcastId,
         UUID productId
 ) {
 

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/request/LiveBroadcastCreateRequestDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/request/LiveBroadcastCreateRequestDto.java
@@ -1,10 +1,8 @@
 package com.live_commerce.livebroadcast.application.dto.request;
 
-import com.live_commerce.livebroadcast.domain.model.BroadcastStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/request/LiveBroadcastCreateRequestDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/request/LiveBroadcastCreateRequestDto.java
@@ -1,6 +1,8 @@
 package com.live_commerce.livebroadcast.application.dto.request;
 
 import com.live_commerce.livebroadcast.domain.model.BroadcastStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,22 +10,11 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Builder
-@Getter
-public class LiveBroadcastCreateRequestDto {
+public record LiveBroadcastCreateRequestDto (
 
-    private String broadcastName;
-
-    private LocalDateTime startTime;
-
-    private LocalDateTime endTime;
-
-    private BroadcastStatus broadcastStatus;
-
-    // 방송 생성하는 사람을 사용자 정보에서 자동 추론
-    private UUID hostId;
-
-    private UUID companyId;
-
-    private Integer totalViewerCount;
-
-}
+        @NotBlank(message = "방송 제목은 필수입니다.") String broadcastName,
+        @NotNull(message = "시작 시간은 필수입니다.") LocalDateTime startTime,
+        @NotNull(message = "종료 시간은 필수입니다.") LocalDateTime endTime,
+        UUID hostId,
+        @NotNull(message = "회사 ID는 필수입니다.") UUID companyId
+) {}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/request/LiveBroadcastUpdateRequestDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/request/LiveBroadcastUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package com.live_commerce.livebroadcast.application.dto.request;
 
 import com.live_commerce.livebroadcast.domain.model.BroadcastStatus;
+import jakarta.validation.constraints.NotBlank;
 
 import java.time.LocalDateTime;
 

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/response/BroadcastProductPageResponse.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/response/BroadcastProductPageResponse.java
@@ -1,0 +1,31 @@
+package com.live_commerce.livebroadcast.application.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record BroadcastProductPageResponse(
+        List<BroadcastProductListResponseDto> products,
+        PaginationMeta pagination
+){
+    public static BroadcastProductPageResponse from(Page<BroadcastProductListResponseDto> page) {
+        return new BroadcastProductPageResponse(
+                page.getContent(),
+                new PaginationMeta(
+                        page.getNumber(),
+                        page.getSize(),
+                        page.getTotalPages(),
+                        page.getTotalElements(),
+                        page.isLast()
+                )
+        );
+    }
+
+    public record PaginationMeta(
+            int currentPage,
+            int pageSize,
+            int totalPages,
+            long totalElements,
+            boolean isLast
+    ) {}
+}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/response/BroadcastProductResponseDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/response/BroadcastProductResponseDto.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import java.util.UUID;
 
 public record BroadcastProductResponseDto (
-        UUID id,
-        UUID broadcastId,
+        UUID broadcastProductId,
+        UUID liveBroadcastId,
         UUID productId
 ){
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/response/LiveBroadcastPageResponse.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/response/LiveBroadcastPageResponse.java
@@ -1,18 +1,17 @@
 package com.live_commerce.livebroadcast.application.dto.response;
 
-import com.live_commerce.livebroadcast.infrastructure.client.product.ProductSummaryDto;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
-public record ProductPageResponse (
-        List<BroadcastProductListResponseDto> products,
+public record LiveBroadcastPageResponse (
+        List<LiveBroadcastResponseDto> products,
         PaginationMeta pagination
 ){
-    public static ProductPageResponse from(Page<BroadcastProductListResponseDto> page) {
-        return new ProductPageResponse(
+    public static LiveBroadcastPageResponse from(Page<LiveBroadcastResponseDto> page) {
+        return new LiveBroadcastPageResponse(
                 page.getContent(),
-                new PaginationMeta(
+                new LiveBroadcastPageResponse.PaginationMeta(
                         page.getNumber(),
                         page.getSize(),
                         page.getTotalPages(),
@@ -30,3 +29,4 @@ public record ProductPageResponse (
             boolean isLast
     ) {}
 }
+

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/response/LiveBroadcastResponseDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/response/LiveBroadcastResponseDto.java
@@ -2,20 +2,18 @@ package com.live_commerce.livebroadcast.application.dto.response;
 
 import com.live_commerce.livebroadcast.domain.model.BroadcastStatus;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Builder
 public record LiveBroadcastResponseDto (
-        UUID id,
+        UUID liveBroadcastId,
         String broadcastName,
         LocalDateTime startTime,
         LocalDateTime endTime,
         BroadcastStatus broadcastStatus,
+        Integer totalViewerCount,
         UUID hostId,
-        UUID companyId,
-        Integer totalViewerCount
-) { }
+        UUID companyId
+) {}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/exception/LiveBroadcastExceptionCode.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/exception/LiveBroadcastExceptionCode.java
@@ -9,12 +9,16 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum LiveBroadcastExceptionCode implements ExceptionCode {
 
-  NOT_FOUND(HttpStatus.NOT_FOUND, "LiveBroadcast Not Found"),
+  NOT_FOUND(HttpStatus.NOT_FOUND, "방송을 찾을 수 없습니다."),
   FORBIDDEN(HttpStatus.FORBIDDEN, "해당 작업을 수행할 권한이 없습니다."),
   ROLE_CHANGE_FORBIDDEN(HttpStatus.FORBIDDEN, "권한(Role)은 마스터만 수정할 수 있습니다."),
   BROADCAST_PRODUCT_ALREADY_CONNECTED(HttpStatus.CONFLICT, "이미 방송과 연결된 상품입니다."),
   EXTERNAL_PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
-  PRODUCT_DISCONNECTED(HttpStatus.NOT_FOUND, "해당 방송과 연결된 상품이 없습니다.");
+  PRODUCT_DISCONNECTED(HttpStatus.NOT_FOUND, "해당 방송과 연결된 상품이 없습니다."),
+  EXTERNAL_COMPANY_NOT_FOUND(HttpStatus.NOT_FOUND, "업체를 찾을 수 없습니다."),
+  EXCEPTION_FIELD_REQUIRED(HttpStatus.BAD_REQUEST, "수정할 항목이 없습니다."),
+  INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "시작 시간은 종료 시간보다 빨라야 합니다.");
+
 
 
 

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/mapper/BroadcastProductMapper.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/mapper/BroadcastProductMapper.java
@@ -10,19 +10,19 @@ public class BroadcastProductMapper {
 
     public static BroadcastProductResponseDto entityToDto(BroadcastProduct entity) {
         return new BroadcastProductResponseDto(
-                entity.getId(),
-                entity.getBroadcastId(),
+                entity.getBroadcastProductId(),
+                entity.getLiveBroadcastId(),
                 entity.getProductId()
         );
     }
 
     public static BroadcastProduct connectDtoToEntity(BroadcastProductConnectDto dto) {
-        return BroadcastProduct.create(dto.broadcastId(), dto.productId());
+        return BroadcastProduct.create(dto.liveBroadcastId(), dto.productId());
     }
 
     public static BroadcastProductConnectDto toConnectDto(LiveBroadcast broadcast, ExternalProductResponseDto productDto) {
         return new BroadcastProductConnectDto(
-                broadcast.getId(),
+                broadcast.getLiveBroadcastId(),
                 productDto.productId()
         );
     }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/mapper/LiveBroadcastMapper.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/mapper/LiveBroadcastMapper.java
@@ -3,6 +3,7 @@ package com.live_commerce.livebroadcast.application.mapper;
 import com.live_commerce.livebroadcast.application.dto.request.LiveBroadcastCreateRequestDto;
 import com.live_commerce.livebroadcast.application.dto.response.LiveBroadcastResponseDto;
 import com.live_commerce.livebroadcast.domain.model.LiveBroadcast;
+import com.live_commerce.livebroadcast.infrastructure.client.company.ExternalCompanyResponseDto;
 
 
 public class LiveBroadcastMapper {
@@ -10,18 +11,18 @@ public class LiveBroadcastMapper {
     public static LiveBroadcast createDtoToEntity(LiveBroadcastCreateRequestDto requestDto) {
 
         return LiveBroadcast.builder()
-                .broadcastName(requestDto.getBroadcastName())
-                .startTime(requestDto.getStartTime())
-                .endTime(requestDto.getEndTime())
-                .hostId(requestDto.getHostId())
-                .companyId(requestDto.getCompanyId())
+                .broadcastName(requestDto.broadcastName())
+                .startTime(requestDto.startTime())
+                .endTime(requestDto.endTime())
+                .hostId(requestDto.hostId())
+                .companyId(requestDto.companyId())
                 .build();
     }
 
     public static LiveBroadcastResponseDto entityToDto(LiveBroadcast entity) {
 
         return LiveBroadcastResponseDto.builder()
-                .id(entity.getId())
+                .liveBroadcastId(entity.getLiveBroadcastId())
                 .broadcastName(entity.getBroadcastName())
                 .broadcastStatus(entity.getBroadcastStatus())
                 .startTime(entity.getStartTime())

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/service/BroadcastProductService.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/service/BroadcastProductService.java
@@ -3,7 +3,7 @@ package com.live_commerce.livebroadcast.application.service;
 import com.live_commerce.livebroadcast.application.dto.request.BroadcastProductConnectDto;
 import com.live_commerce.livebroadcast.application.dto.response.BroadcastProductListResponseDto;
 import com.live_commerce.livebroadcast.application.dto.response.BroadcastProductResponseDto;
-import com.live_commerce.livebroadcast.application.dto.response.ProductPageResponse;
+import com.live_commerce.livebroadcast.application.dto.response.BroadcastProductPageResponse;
 import com.live_commerce.livebroadcast.application.mapper.BroadcastProductMapper;
 import com.live_commerce.livebroadcast.application.validation.LiveBroadcastValidator;
 import com.live_commerce.livebroadcast.application.validation.ProductValidator;
@@ -42,13 +42,13 @@ public class BroadcastProductService {
 
 
     @Transactional
-    public BroadcastProductResponseDto connectBroadcastProduct(UUID broadcastId, BroadcastProductConnectDto requestDto) {
+    public BroadcastProductResponseDto connectBroadcastProduct(UUID liveBroadcastId, BroadcastProductConnectDto requestDto) {
 
-        LiveBroadcast broadcast = liveBroadcastValidator.validateExists(broadcastId);
+        LiveBroadcast broadcast = liveBroadcastValidator.validateExists(liveBroadcastId);
 
         ExternalProductResponseDto productDto = productValidator.getValidProductOrThrow(requestDto.productId());
 
-        liveBroadcastValidator.validateNotConnected(broadcast.getId(), productDto.productId());
+        liveBroadcastValidator.validateNotConnected(broadcast.getLiveBroadcastId(), productDto.productId());
 
         BroadcastProductConnectDto connectDto = BroadcastProductMapper.toConnectDto(broadcast, productDto);
         BroadcastProduct broadcastProduct = BroadcastProductMapper.connectDtoToEntity(connectDto);
@@ -59,17 +59,17 @@ public class BroadcastProductService {
     }
 
     @Transactional
-    public void disconnectBroadcastProduct(UUID broadcastId, UUID productId) {
-        LiveBroadcast broadcast = liveBroadcastValidator.validateExists(broadcastId);
+    public void disconnectBroadcastProduct(UUID liveBroadcastId, UUID productId) {
+        LiveBroadcast broadcast = liveBroadcastValidator.validateExists(liveBroadcastId);
 
-        BroadcastProduct broadcastProduct = liveBroadcastValidator.validateConnectedProductExists(broadcast.getId(), productId);
+        BroadcastProduct broadcastProduct = liveBroadcastValidator.validateConnectedProductExists(broadcast.getLiveBroadcastId(), productId);
 
         broadcastProduct.delete("temp");
     }
 
     @Transactional(readOnly = true)
-    public ProductPageResponse getBroadcastProducts(UUID broadcastId, Pageable pageable) {
-        Page<UUID> productIds = broadcastProductQueryRepository.findProductIdsByBroadcastId(broadcastId, pageable);
+    public BroadcastProductPageResponse getBroadcastProducts(UUID liveBroadcastId, Pageable pageable) {
+        Page<UUID> productIds = broadcastProductQueryRepository.findProductIdsByBroadcastId(liveBroadcastId, pageable);
 
         //TODO validator 에다가 빼버려
         List<ProductSummaryDto> productSummaries = productClient.getProducts(productIds.getContent()).getData();
@@ -85,14 +85,14 @@ public class BroadcastProductService {
 
         Page<BroadcastProductListResponseDto> page = new PageImpl<>(content, pageable, productIds.getTotalElements());
 
-        return ProductPageResponse.from(page);
+        return BroadcastProductPageResponse.from(page);
     }
 
 
     @Transactional(readOnly = true)
-    public boolean existsByBroadcastIdAndProductId(UUID broadcastId, UUID productId) {
-        liveBroadcastValidator.validateExists(broadcastId);
+    public boolean existsByBroadcastIdAndProductId(UUID liveBroadcastId, UUID productId) {
+        liveBroadcastValidator.validateExists(liveBroadcastId);
 
-        return broadcastProductRepository.existsByBroadcastIdAndProductIdAndDeletedStatusFalse(broadcastId, productId);
+        return broadcastProductRepository.existsByLiveBroadcastIdAndProductIdAndDeletedStatusFalse(liveBroadcastId, productId);
     }
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/service/BroadcastProductService.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/service/BroadcastProductService.java
@@ -71,8 +71,7 @@ public class BroadcastProductService {
     public BroadcastProductPageResponse getBroadcastProducts(UUID liveBroadcastId, Pageable pageable) {
         Page<UUID> productIds = broadcastProductQueryRepository.findProductIdsByBroadcastId(liveBroadcastId, pageable);
 
-        //TODO validator 에다가 빼버려
-        List<ProductSummaryDto> productSummaries = productClient.getProducts(productIds.getContent()).getData();
+        List<ProductSummaryDto> productSummaries = productValidator.getValidProductsOrThrow(productIds.getContent());
 
         Map<UUID, ProductSummaryDto> summaryMap = productSummaries.stream()
                 .collect(Collectors.toMap(ProductSummaryDto::id, Function.identity()));

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/service/LiveBroadcastService.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/service/LiveBroadcastService.java
@@ -1,14 +1,20 @@
 package com.live_commerce.livebroadcast.application.service;
 
 import com.live_commerce.livebroadcast.application.dto.request.LiveBroadcastCreateRequestDto;
+import com.live_commerce.livebroadcast.application.dto.response.LiveBroadcastPageResponse;
 import com.live_commerce.livebroadcast.application.dto.response.LiveBroadcastResponseDto;
 import com.live_commerce.livebroadcast.application.dto.request.LiveBroadcastUpdateRequestDto;
 import com.live_commerce.livebroadcast.application.mapper.LiveBroadcastMapper;
-import com.live_commerce.livebroadcast.domain.exception.LiveBroadcastException;
+import com.live_commerce.livebroadcast.application.validation.CompanyValidator;
+import com.live_commerce.livebroadcast.application.validation.LiveBroadcastValidator;
 import com.live_commerce.livebroadcast.domain.model.LiveBroadcast;
+import com.live_commerce.livebroadcast.domain.repository.LiveBroadcastQueryRepository;
 import com.live_commerce.livebroadcast.domain.repository.LiveBroadcastRepository;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,9 +25,14 @@ import java.util.UUID;
 public class LiveBroadcastService {
 
     private final LiveBroadcastRepository liveBroadcastRepository;
+    private final LiveBroadcastValidator liveBroadcastValidator;
+    private final CompanyValidator companyValidator;
+    private final LiveBroadcastQueryRepository liveBroadcastQueryRepository;
 
     @Transactional
     public LiveBroadcastResponseDto createBroadcast(LiveBroadcastCreateRequestDto requestDto) {
+        liveBroadcastValidator.validateCreatableRequest(requestDto);
+        companyValidator.validateExistsAndActiveOrThrow(requestDto.companyId());
         LiveBroadcast liveBroadcast = LiveBroadcastMapper.createDtoToEntity(requestDto);
         liveBroadcastRepository.save(liveBroadcast);
         return LiveBroadcastMapper.entityToDto(liveBroadcast);
@@ -29,31 +40,41 @@ public class LiveBroadcastService {
 
     @Transactional(readOnly = true)
     public LiveBroadcastResponseDto getLiveBroadcast(UUID id) {
-        LiveBroadcast liveBroadcast = liveBroadcastRepository.findById(id)
-                .filter(h -> !h.getDeletedStatus())
-                .orElseThrow(() -> new IllegalArgumentException("No live broadcast exists with id: " + id));
+        LiveBroadcast liveBroadcast = liveBroadcastValidator.validateExists(id);
         return LiveBroadcastMapper.entityToDto(liveBroadcast);
     }
 
     @Transactional
     public LiveBroadcastResponseDto updateLiveBroadcast(UUID id, LiveBroadcastUpdateRequestDto requestDto) {
-        LiveBroadcast broadcast = liveBroadcastRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("No live broadcast exists with id: " + id));
-
-        broadcast.update(requestDto);
-        return LiveBroadcastMapper.entityToDto(broadcast);
+        LiveBroadcast liveBroadcast = liveBroadcastValidator.validateExists(id);
+        liveBroadcastValidator.validateUpdateRequest(requestDto, liveBroadcast);
+        liveBroadcast.update(requestDto);
+        return LiveBroadcastMapper.entityToDto(liveBroadcast);
     }
 
     @Transactional
     public void deleteBroadcast(UUID id) {
-        LiveBroadcast broadcast = liveBroadcastRepository.findByIdAndDeletedStatusFalse(id).orElse(null);
-
-        if (broadcast == null) {
-            LiveBroadcastException.forLiveBroadcastNotFound();
-            return;
-        }
-
+        LiveBroadcast broadcast = liveBroadcastValidator.validateExists(id);
         broadcast.delete("temp");
     }
 
+    @Transactional(readOnly = true)
+    public LiveBroadcastPageResponse searchLiveBroadcast(String keyword, Pageable pageable) {
+        int requestedSize = pageable.getPageSize();
+        int validSize = switch (requestedSize) {
+            case 30, 50 -> requestedSize;
+            default -> 10;
+        };
+
+        Pageable validatedPageable = PageRequest.of(
+                pageable.getPageNumber(),
+                validSize,
+                Sort.by(Sort.Direction.DESC, "createdAt")
+        );
+
+        Page<LiveBroadcastResponseDto> page = liveBroadcastQueryRepository
+                .searchByBroadcastName(keyword, validatedPageable);
+
+        return LiveBroadcastPageResponse.from(page);
+    }
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/validation/CompanyValidator.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/validation/CompanyValidator.java
@@ -1,0 +1,35 @@
+package com.live_commerce.livebroadcast.application.validation;
+
+import com.live_commerce.livebroadcast.domain.exception.LiveBroadcastException;
+import com.live_commerce.livebroadcast.infrastructure.client.company.CompanyClient;
+import com.live_commerce.livebroadcast.infrastructure.client.company.ExternalCompanyResponseDto;
+import com.live_commerce.livebroadcast.presentation.common.ApiResponse;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class CompanyValidator {
+
+    private final CompanyClient companyClient;
+
+    public void validateExistsAndActiveOrThrow(UUID companyId) {
+        try {
+            ApiResponse<ExternalCompanyResponseDto> companyResponse = companyClient.getCompany(companyId);
+
+            if (companyResponse.getData() == null) {
+                throw LiveBroadcastException.forExternalCompanyNotFound();
+            }
+
+        } catch (FeignException.NotFound e) {
+            throw LiveBroadcastException.forExternalCompanyNotFound();
+        } catch (FeignException e) {
+            throw new RuntimeException("업체 서비스 호출 실패", e);
+        }
+    }
+
+
+}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/validation/LiveBroadcastValidator.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/validation/LiveBroadcastValidator.java
@@ -1,6 +1,8 @@
 package com.live_commerce.livebroadcast.application.validation;
 
 
+import com.live_commerce.livebroadcast.application.dto.request.LiveBroadcastCreateRequestDto;
+import com.live_commerce.livebroadcast.application.dto.request.LiveBroadcastUpdateRequestDto;
 import com.live_commerce.livebroadcast.domain.exception.LiveBroadcastException;
 import com.live_commerce.livebroadcast.domain.model.BroadcastProduct;
 import com.live_commerce.livebroadcast.domain.model.LiveBroadcast;
@@ -9,6 +11,7 @@ import com.live_commerce.livebroadcast.domain.repository.LiveBroadcastRepository
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Component
@@ -23,7 +26,7 @@ public class LiveBroadcastValidator {
      * 존재하는 방송인지 검증하고 반환
      */
     public LiveBroadcast validateExists(UUID broadcastId) {
-        return liveBroadcastRepository.findByIdAndDeletedStatusFalse(broadcastId)
+        return liveBroadcastRepository.findByLiveBroadcastIdAndDeletedStatusFalse(broadcastId)
                 .orElseThrow(LiveBroadcastException::forLiveBroadcastNotFound);
     }
 
@@ -31,7 +34,7 @@ public class LiveBroadcastValidator {
      * 방송에 이미 연결된 상품인지 검증 (연결되어 있으면 예외 발생)
      */
     public void validateNotConnected(UUID broadcastId, UUID productId) {
-        if (broadcastProductRepository.existsByBroadcastIdAndProductIdAndDeletedStatusFalse(broadcastId, productId)) {
+        if (broadcastProductRepository.existsByLiveBroadcastIdAndProductIdAndDeletedStatusFalse(broadcastId, productId)) {
             throw LiveBroadcastException.forProductAlreadyConnected();
         }
     }
@@ -40,9 +43,41 @@ public class LiveBroadcastValidator {
      * 방송에 연결된 상품이 존재하는지 검증하고 반환 (없으면 예외 발생)
      */
     public BroadcastProduct validateConnectedProductExists(UUID broadcastId, UUID productId) {
-        return broadcastProductRepository.findByBroadcastIdAndProductIdAndDeletedStatusFalse(broadcastId, productId)
+        return broadcastProductRepository.findByLiveBroadcastIdAndProductIdAndDeletedStatusFalse(broadcastId, productId)
                 .orElseThrow(LiveBroadcastException::forConnectedProductNotFound);
 
+    }
+
+    /**
+     * 라이브 방송 생성 시, 시작 시간과 종료 시간의 유효성을 검증합니다.
+     */
+    public void validateCreatableRequest(LiveBroadcastCreateRequestDto dto) {
+        if (!dto.startTime().isBefore(dto.endTime())) {
+            throw LiveBroadcastException.forInvalidTimeRange();
+        }
+    }
+
+    /**
+     * 라이브 방송 수정 요청에 대한 유효성 검증을 수행합니다.
+     */
+    public void validateUpdateRequest(LiveBroadcastUpdateRequestDto dto, LiveBroadcast current) {
+
+        boolean allNullOrBlank =
+                (dto.broadcastName() == null || dto.broadcastName().isBlank()) &&
+                        dto.startTime() == null &&
+                        dto.endTime() == null &&
+                        dto.broadcastStatus() == null;
+
+        if (allNullOrBlank) {
+            throw LiveBroadcastException.forUpdateFieldRequired();
+        }
+
+        LocalDateTime start = dto.startTime() != null ? dto.startTime() : current.getStartTime();
+        LocalDateTime end = dto.endTime() != null ? dto.endTime() : current.getEndTime();
+
+        if (!start.isBefore(end)) {
+            throw LiveBroadcastException.forInvalidTimeRange();
+        }
     }
 
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/validation/ProductValidator.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/validation/ProductValidator.java
@@ -3,11 +3,13 @@ package com.live_commerce.livebroadcast.application.validation;
 import com.live_commerce.livebroadcast.domain.exception.LiveBroadcastException;
 import com.live_commerce.livebroadcast.infrastructure.client.product.ExternalProductResponseDto;
 import com.live_commerce.livebroadcast.infrastructure.client.product.ProductClient;
+import com.live_commerce.livebroadcast.infrastructure.client.product.ProductSummaryDto;
 import com.live_commerce.livebroadcast.presentation.common.ApiResponse;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -31,4 +33,22 @@ public class ProductValidator {
             throw new RuntimeException("상품 서비스 호출 실패", e);
         }
     }
+
+    public List<ProductSummaryDto> getValidProductsOrThrow(List<UUID> productIds) {
+        try {
+            ApiResponse<List<ProductSummaryDto>> response = productClient.getProducts(productIds);
+            List<ProductSummaryDto> data = response.getData();
+
+            if (data == null || data.size() != productIds.size()) {
+                throw LiveBroadcastException.forExternalProductNotFound(); // 일부 없을 수 있음
+            }
+
+            return data;
+        } catch (FeignException.NotFound e) {
+            throw LiveBroadcastException.forExternalProductNotFound();
+        } catch (FeignException e) {
+            throw new RuntimeException("상품 서비스 호출 실패", e);
+        }
+    }
+
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/exception/LiveBroadcastException.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/exception/LiveBroadcastException.java
@@ -10,23 +10,30 @@ public class LiveBroadcastException extends CustomException {
     }
 
     public static LiveBroadcastException forLiveBroadcastNotFound() {
-        throw new LiveBroadcastException(LiveBroadcastExceptionCode.NOT_FOUND);
+        return new LiveBroadcastException(LiveBroadcastExceptionCode.NOT_FOUND);
     }
 
-
-//    public static LiveBroadcastException forProductAlreadyConnectedToBroadcast() {
-//        throw new LiveBroadcastException(LiveBroadcastExceptionCode.BROADCAST_PRODUCT_NOT_CONNECTED);
-//    }
-
     public static LiveBroadcastException forProductAlreadyConnected() {
-        throw new LiveBroadcastException(LiveBroadcastExceptionCode.BROADCAST_PRODUCT_ALREADY_CONNECTED);
+        return new LiveBroadcastException(LiveBroadcastExceptionCode.BROADCAST_PRODUCT_ALREADY_CONNECTED);
     }
 
     public static LiveBroadcastException forExternalProductNotFound() {
-        throw new LiveBroadcastException(LiveBroadcastExceptionCode.EXTERNAL_PRODUCT_NOT_FOUND);
+        return new LiveBroadcastException(LiveBroadcastExceptionCode.EXTERNAL_PRODUCT_NOT_FOUND);
     }
 
     public static LiveBroadcastException forConnectedProductNotFound() {
-        throw new LiveBroadcastException(LiveBroadcastExceptionCode.PRODUCT_DISCONNECTED);
+        return new LiveBroadcastException(LiveBroadcastExceptionCode.PRODUCT_DISCONNECTED);
+    }
+
+    public static LiveBroadcastException forExternalCompanyNotFound() {
+        return new LiveBroadcastException(LiveBroadcastExceptionCode.EXTERNAL_COMPANY_NOT_FOUND);
+    }
+
+    public static LiveBroadcastException forInvalidTimeRange() {
+        return new LiveBroadcastException(LiveBroadcastExceptionCode.INVALID_TIME_RANGE);
+    }
+
+    public static LiveBroadcastException forUpdateFieldRequired() {
+        return new LiveBroadcastException(LiveBroadcastExceptionCode.EXCEPTION_FIELD_REQUIRED);
     }
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/model/BroadcastProduct.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/model/BroadcastProduct.java
@@ -19,19 +19,19 @@ public class BroadcastProduct extends BaseEntity{
 
     @Id
     @UuidGenerator
-    private UUID id;
+    private UUID broadcastProductId;
 
-    private UUID broadcastId;
+    private UUID liveBroadcastId;
 
     private UUID productId;
 
-    private BroadcastProduct(UUID broadcastId, UUID productId) {
-        this.broadcastId = broadcastId;
+    private BroadcastProduct(UUID liveBroadcastId, UUID productId) {
+        this.liveBroadcastId = liveBroadcastId;
         this.productId = productId;
     }
 
-    public static BroadcastProduct create(UUID broadcastId, UUID productId) {
-        return new BroadcastProduct(broadcastId, productId);
+    public static BroadcastProduct create(UUID liveBroadcastId, UUID productId) {
+        return new BroadcastProduct(liveBroadcastId, productId);
     }
 
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/model/LiveBroadcast.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/model/LiveBroadcast.java
@@ -20,7 +20,7 @@ public class LiveBroadcast extends BaseEntity {
 
     @Id
     @UuidGenerator
-    private UUID id;
+    private UUID liveBroadcastId;
 
     @Column(nullable = false)
     private String broadcastName;

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/repository/BroadcastProductQueryRepositoryImpl.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/repository/BroadcastProductQueryRepositoryImpl.java
@@ -27,14 +27,14 @@ public class BroadcastProductQueryRepositoryImpl implements BroadcastProductQuer
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<UUID> findProductIdsByBroadcastId(UUID broadcastId, Pageable pageable) {
+    public Page<UUID> findProductIdsByBroadcastId(UUID liveBroadcastId, Pageable pageable) {
         QBroadcastProduct bp = QBroadcastProduct.broadcastProduct;
 
         List<UUID> productIds = queryFactory
                 .select(bp.productId)
                 .from(bp)
                 .where(
-                        bp.broadcastId.eq(broadcastId),
+                        bp.liveBroadcastId.eq(liveBroadcastId),
                         bp.deletedStatus.isFalse()
                 )
                 .orderBy(getOrderSpecifier(pageable.getSort(), bp))
@@ -47,7 +47,7 @@ public class BroadcastProductQueryRepositoryImpl implements BroadcastProductQuer
                         .select(bp.count())
                         .from(bp)
                         .where(
-                                bp.broadcastId.eq(broadcastId),
+                                bp.liveBroadcastId.eq(liveBroadcastId),
                                 bp.deletedStatus.isFalse()
                         )
                         .fetchOne()

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/repository/BroadcastProductRepository.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/repository/BroadcastProductRepository.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public interface BroadcastProductRepository {
     <S extends BroadcastProduct> S save(S broadcastProduct);
 
-    boolean existsByBroadcastIdAndProductIdAndDeletedStatusFalse(UUID broadcastId, UUID productId);
+    boolean existsByLiveBroadcastIdAndProductIdAndDeletedStatusFalse(UUID liveBroadcastId, UUID productId);
 
-    Optional<BroadcastProduct> findByBroadcastIdAndProductIdAndDeletedStatusFalse(UUID broadcastId, UUID productId);
+    Optional<BroadcastProduct> findByLiveBroadcastIdAndProductIdAndDeletedStatusFalse(UUID liveBroadcastId, UUID productId);
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/repository/LiveBroadcastQueryRepository.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/repository/LiveBroadcastQueryRepository.java
@@ -1,0 +1,10 @@
+package com.live_commerce.livebroadcast.domain.repository;
+
+import com.live_commerce.livebroadcast.application.dto.response.LiveBroadcastResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface LiveBroadcastQueryRepository {
+
+    Page<LiveBroadcastResponseDto> searchByBroadcastName(String keyword, Pageable pageable);
+}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/repository/LiveBroadcastQueryRepositoryImpl.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/repository/LiveBroadcastQueryRepositoryImpl.java
@@ -1,0 +1,64 @@
+package com.live_commerce.livebroadcast.domain.repository;
+
+import com.live_commerce.livebroadcast.application.dto.response.LiveBroadcastResponseDto;
+import com.live_commerce.livebroadcast.domain.model.QLiveBroadcast;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LiveBroadcastQueryRepositoryImpl implements LiveBroadcastQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QLiveBroadcast liveBroadcast = QLiveBroadcast.liveBroadcast;
+
+    @Override
+    public Page<LiveBroadcastResponseDto> searchByBroadcastName(String keyword, Pageable pageable) {
+        BooleanExpression condition = StringUtils.hasText(keyword)
+                ? liveBroadcast.broadcastName.containsIgnoreCase(keyword)
+                : null;
+
+        BooleanExpression notDeleted = liveBroadcast.deletedStatus.eq(false);
+
+        List<LiveBroadcastResponseDto> content = queryFactory
+                .select(Projections.constructor(
+                        LiveBroadcastResponseDto.class,
+                        liveBroadcast.liveBroadcastId,
+                        liveBroadcast.broadcastName,
+                        liveBroadcast.startTime,
+                        liveBroadcast.endTime,
+                        liveBroadcast.broadcastStatus,
+                        liveBroadcast.totalViewerCount,
+                        liveBroadcast.hostId,
+                        liveBroadcast.companyId
+                ))
+                .from(liveBroadcast)
+                .where(notDeleted, condition)
+                .orderBy(liveBroadcast.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = Optional.ofNullable(
+                queryFactory
+                        .select(liveBroadcast.count())
+                        .from(liveBroadcast)
+                        .where(notDeleted, condition)
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(content, pageable, total);
+    }
+
+
+}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/repository/LiveBroadcastRepository.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/repository/LiveBroadcastRepository.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 
 public interface LiveBroadcastRepository {
     <S extends LiveBroadcast> S save(S liveBroadcast);
-    Optional<LiveBroadcast> findById(UUID id);
-    Optional<LiveBroadcast> findByIdAndDeletedStatusFalse(UUID id);
-    boolean existsByIdAndDeletedStatusFalse(UUID broadcastId);
+    Optional<LiveBroadcast> findByLiveBroadcastIdAndDeletedStatusFalse(UUID id);
+    boolean existsByLiveBroadcastIdAndDeletedStatusFalse(UUID broadcastId);
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/company/CompanyClient.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/company/CompanyClient.java
@@ -12,5 +12,5 @@ import java.util.UUID;
 public interface CompanyClient {
 
     @GetMapping("/api/v1/companies/{id}")
-    ApiResponse getCompanyById(@PathVariable("id") UUID id);
+    ApiResponse<ExternalCompanyResponseDto> getCompany(@PathVariable("id") UUID id);
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/company/ExternalCompanyResponseDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/company/ExternalCompanyResponseDto.java
@@ -1,8 +1,9 @@
 package com.live_commerce.livebroadcast.infrastructure.client.company;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.UUID;
 
-public class ExternalCompanyResponseDto {
-
-    private UUID companyId;
-}
+public record ExternalCompanyResponseDto (
+        @JsonProperty("id") UUID companyId
+) {}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/product/ProductClient.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/product/ProductClient.java
@@ -20,7 +20,4 @@ public interface ProductClient {
     @PostMapping("/api/v1/products/bulk")
     ApiResponse<List<ProductSummaryDto>> getProducts(@RequestBody List<UUID> productIds);
 
-    @GetMapping("/api/v1/companies/{companyId}")
-    ApiResponse<ExternalCompanyResponseDto> getCompany(@PathVariable("companyId") UUID companyId);
-
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/config/FeignConfig.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/config/FeignConfig.java
@@ -10,12 +10,7 @@ public class FeignConfig {
 
     @Bean
     public ErrorDecoder errorDecoder() {
-        return (methodKey, response) -> {
-            if (response.status() == 404) {
-                return LiveBroadcastException.forExternalProductNotFound();
-            }
-            return new RuntimeException("Feign Error: " + response.status());
-        };
+        return new ErrorDecoder.Default();
     }
 
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/exception/GlobalExceptionHandler.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/exception/GlobalExceptionHandler.java
@@ -1,20 +1,79 @@
 package com.live_commerce.livebroadcast.infrastructure.exception;
 
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.live_commerce.livebroadcast.application.exception.CustomException;
 import com.live_commerce.livebroadcast.infrastructure.common.ResponseUtil;
 import com.live_commerce.livebroadcast.presentation.common.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ApiResponse<String>> handleCustomException(CustomException ex) {
+
 		return ResponseUtil.customResponse(
 			ex.getExceptionCode().getHttpStatus(),
 			ex.getMessage()
 		);
-	}}
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ApiResponse<String>> handleUnexpectedException(Exception ex) {
+		ex.printStackTrace(); // 로그 확인용
+		return ResponseUtil.customResponse(
+				HttpStatus.INTERNAL_SERVER_ERROR,
+				"서버 내부 오류가 발생했습니다."
+		);
+	}
+
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ApiResponse<String>> handleTypeMismatch(MethodArgumentTypeMismatchException ex) {
+
+		String paramName = ex.getName();
+		Object invalidValue = ex.getValue();
+
+		String message = String.format("잘못된 형식의 %s입니다. 입력값: %s", paramName, invalidValue);
+
+		return ResponseUtil.customResponse(HttpStatus.BAD_REQUEST, message);
+	}
+
+	@ExceptionHandler(HttpMessageNotReadableException.class)
+	public ResponseEntity<ApiResponse<String>> handleInvalidJson(HttpMessageNotReadableException ex) {
+		Throwable cause = ex.getCause();
+
+		if (cause instanceof InvalidFormatException ife) {
+			if (ife.getTargetType().isEnum()) {
+				return ResponseUtil.customResponse(
+						HttpStatus.BAD_REQUEST,
+						String.format(
+								"'%s'은(는) 올바르지 않은 상태값입니다",
+								ife.getValue()
+						)
+				);
+			}
+		}
+
+		if (cause instanceof InvalidFormatException ife && ife.getTargetType().equals(LocalDateTime.class)) {
+			return ResponseUtil.customResponse(
+					HttpStatus.BAD_REQUEST,
+					"날짜 형식이 잘못되었습니다. yyyy-MM-dd'T'HH:mm:ss 형식으로 입력해주세요."
+			);
+		}
+
+		return ResponseUtil.customResponse(
+				HttpStatus.BAD_REQUEST,
+				"잘못된 요청입니다. 요청 형식을 다시 확인해주세요."
+		);
+	}
+
+}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/repository/JpaBroadcastProductRepository.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/repository/JpaBroadcastProductRepository.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Repository
 public interface JpaBroadcastProductRepository extends JpaRepository<BroadcastProduct, UUID>, BroadcastProductRepository {
 
-    boolean existsByBroadcastIdAndProductIdAndDeletedStatusFalse(UUID broadcastId, UUID productId);
+    boolean existsByLiveBroadcastIdAndProductIdAndDeletedStatusFalse(UUID liveBroadcastId, UUID productId);
 
-    Optional<BroadcastProduct> findByBroadcastIdAndProductIdAndDeletedStatusFalse(UUID broadcastId, UUID productId);
+    Optional<BroadcastProduct> findByLiveBroadcastIdAndProductIdAndDeletedStatusFalse(UUID liveBroadcastId, UUID productId);
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/repository/JpaLiveBroadcastRepository.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/repository/JpaLiveBroadcastRepository.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Repository
 public interface JpaLiveBroadcastRepository extends JpaRepository<LiveBroadcast, UUID>, LiveBroadcastRepository {
 
-    Optional<LiveBroadcast> findByIdAndDeletedStatusFalse(UUID id);
+    Optional<LiveBroadcast> findByLiveBroadcastIdAndDeletedStatusFalse(UUID id);
 
-    boolean existsByIdAndDeletedStatusFalse(UUID broadcastId);
+    boolean existsByLiveBroadcastIdAndDeletedStatusFalse(UUID broadcastId);
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/presentation/controller/BroadcastProductController.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/presentation/controller/BroadcastProductController.java
@@ -1,16 +1,15 @@
 package com.live_commerce.livebroadcast.presentation.controller;
 
 import com.live_commerce.livebroadcast.application.dto.request.BroadcastProductConnectDto;
-import com.live_commerce.livebroadcast.application.dto.response.BroadcastProductListResponseDto;
 import com.live_commerce.livebroadcast.application.dto.response.BroadcastProductResponseDto;
-import com.live_commerce.livebroadcast.application.dto.response.ExistsResponseDto;
-import com.live_commerce.livebroadcast.application.dto.response.ProductPageResponse;
+import com.live_commerce.livebroadcast.application.dto.response.BroadcastProductPageResponse;
 import com.live_commerce.livebroadcast.application.service.BroadcastProductService;
 import com.live_commerce.livebroadcast.infrastructure.common.ResponseUtil;
 import com.live_commerce.livebroadcast.presentation.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,11 +41,11 @@ public class BroadcastProductController {
     }
 
     @GetMapping("")
-    public ResponseEntity<ApiResponse<ProductPageResponse>> getProducts(
+    public ResponseEntity<ApiResponse<BroadcastProductPageResponse>> getProducts(
             @PathVariable UUID broadcastId,
-            Pageable pageable
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        ProductPageResponse response = broadcastProductService.getBroadcastProducts(broadcastId, pageable);
+        BroadcastProductPageResponse response = broadcastProductService.getBroadcastProducts(broadcastId, pageable);
         return ResponseUtil.success(response);
     }
 

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/presentation/controller/LiveBroadcastController.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/presentation/controller/LiveBroadcastController.java
@@ -1,6 +1,7 @@
 package com.live_commerce.livebroadcast.presentation.controller;
 
 import com.live_commerce.livebroadcast.application.dto.request.LiveBroadcastCreateRequestDto;
+import com.live_commerce.livebroadcast.application.dto.response.LiveBroadcastPageResponse;
 import com.live_commerce.livebroadcast.application.dto.response.LiveBroadcastResponseDto;
 import com.live_commerce.livebroadcast.application.dto.request.LiveBroadcastUpdateRequestDto;
 import com.live_commerce.livebroadcast.application.service.LiveBroadcastService;
@@ -8,8 +9,12 @@ import com.live_commerce.livebroadcast.infrastructure.common.ResponseUtil;
 import com.live_commerce.livebroadcast.presentation.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 
 import java.util.UUID;
 
@@ -21,31 +26,46 @@ public class LiveBroadcastController {
 
     private final LiveBroadcastService liveBroadcastService;
 
-
     @PostMapping
-    public ResponseEntity<ApiResponse<LiveBroadcastResponseDto>> createBroadcast(@RequestBody LiveBroadcastCreateRequestDto requestDto) {
-
+    public ResponseEntity<ApiResponse<LiveBroadcastResponseDto>> createBroadcast(
+            @RequestBody LiveBroadcastCreateRequestDto requestDto
+    ) {
         LiveBroadcastResponseDto responseDto = liveBroadcastService.createBroadcast(requestDto);
-
         return ResponseUtil.success(responseDto);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponse<LiveBroadcastResponseDto>> getBroadcast(@PathVariable UUID id) {
+    public ResponseEntity<ApiResponse<LiveBroadcastResponseDto>> getBroadcast(
+            @PathVariable UUID id
+    ) {
         LiveBroadcastResponseDto responseDto = liveBroadcastService.getLiveBroadcast(id);
         return ResponseUtil.success(responseDto);
     }
 
 
     @PatchMapping("/{id}")
-    public ResponseEntity<ApiResponse<LiveBroadcastResponseDto>> updateBroadcast(@PathVariable UUID id, @RequestBody LiveBroadcastUpdateRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<LiveBroadcastResponseDto>> updateBroadcast(
+            @PathVariable UUID id,
+            @RequestBody LiveBroadcastUpdateRequestDto requestDto
+    ) {
         LiveBroadcastResponseDto responseDto = liveBroadcastService.updateLiveBroadcast(id, requestDto);
         return ResponseUtil.success(responseDto);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<String>> deleteBroadcast(@PathVariable UUID id) {
+    public ResponseEntity<ApiResponse<String>> deleteBroadcast(
+            @PathVariable UUID id
+    ) {
         liveBroadcastService.deleteBroadcast(id);
         return ResponseUtil.success("라이브 방송이 삭제되었습니다.");
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<LiveBroadcastPageResponse>> searchBroadcast(
+            @RequestParam(required = false) String keyword,
+            Pageable pageable
+    ) {
+        LiveBroadcastPageResponse response = liveBroadcastService.searchLiveBroadcast(keyword, pageable);
+        return ResponseUtil.success(response);
     }
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/presentation/controller/LiveBroadcastController.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/presentation/controller/LiveBroadcastController.java
@@ -7,6 +7,7 @@ import com.live_commerce.livebroadcast.application.dto.request.LiveBroadcastUpda
 import com.live_commerce.livebroadcast.application.service.LiveBroadcastService;
 import com.live_commerce.livebroadcast.infrastructure.common.ResponseUtil;
 import com.live_commerce.livebroadcast.presentation.common.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.data.domain.Pageable;
@@ -28,7 +29,7 @@ public class LiveBroadcastController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<LiveBroadcastResponseDto>> createBroadcast(
-            @RequestBody LiveBroadcastCreateRequestDto requestDto
+            @RequestBody @Valid LiveBroadcastCreateRequestDto requestDto
     ) {
         LiveBroadcastResponseDto responseDto = liveBroadcastService.createBroadcast(requestDto);
         return ResponseUtil.success(responseDto);

--- a/client/livebroadcast/src/test/java/com/live_commerce/livebroadcast/LiveBroadcastServiceTest.java
+++ b/client/livebroadcast/src/test/java/com/live_commerce/livebroadcast/LiveBroadcastServiceTest.java
@@ -50,8 +50,8 @@ public class LiveBroadcastServiceTest {
 
         // then
         assertNotNull(responseDto);
-        assertEquals(requestDto.getBroadcastName(), responseDto.getBroadcastName());
-        assertEquals(requestDto.getStartTime(), responseDto.getStartTime());
+        assertEquals(requestDto.broadcastName(), responseDto.broadcastName());
+        assertEquals(requestDto.startTime(), responseDto.startTime());
 
         // repository.save가 실제로 호출되었는지 검증
         Mockito.verify(liveBroadcastRepository, Mockito.times(1)).save(Mockito.any(LiveBroadcast.class));


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 라이브방송 검색기능 구현 및 리팩토링

* **세부 내용**

**📌 라이브방송 기본키 필드명 변경 안내**

라이브방송 엔티티의 기본키 필드명을 `id`에서 `liveBroadcastId`로 변경하였습니다.  
단순한 `id`보다 해당 도메인을 명확히 나타내는 이름으로, 코드 가독성과 의도 파악이 쉬워지도록 수정했습니다.  
**FeignClient 등에서 라이브방송 정보를 조회할 경우, 해당 필드명을 참고해주시면 감사하겠습니다.**


## 💡 추가 설명
![image](https://github.com/user-attachments/assets/d2e0beef-9d68-46fb-a03f-73ece77e9b81)
라이브방송 검색(GET http://localhost:19060/api/v1/livebroadcasts/search)

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
