### PR TITLE
feat: 라이브 방송 알림 등록 기능 구현 (KAN-47)

### DIFF
--- a/client/notification/build.gradle
+++ b/client/notification/build.gradle
@@ -28,6 +28,9 @@ ext {
 }
 
 dependencies {
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'com.fasterxml.jackson.module:jackson-module-parameter-names:2.15.0'

--- a/client/notification/src/main/java/com/live_commerce/notification/application/kafka/NotificationConsumer.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/application/kafka/NotificationConsumer.java
@@ -1,0 +1,30 @@
+package com.live_commerce.notification.application.kafka;
+
+import com.live_commerce.notification.application.service.NotificationService;
+import com.live_commerce.notification.domain.model.Notification;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationConsumer {
+
+  private final NotificationService notificationService;
+  private final KafkaTemplate<String, String> kafkaTemplate;
+
+  public void consumerNotification(String notificationId){
+    UUID notificationUuid = UUID.fromString(notificationId);
+
+    // 알림 처리
+    notificationService.sendNotification(notificationUuid);
+
+    // 알림 정보 카프카에 전송
+    Notification notificatrion = notificationService.getNotification(notificationUuid);
+    String message  = notificatrion.getMessage();
+    String topic = "notification-topic";
+
+    kafkaTemplate.send(topic, message);
+  }
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/application/kafka/NotificationProducer.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/application/kafka/NotificationProducer.java
@@ -1,0 +1,20 @@
+package com.live_commerce.notification.application.kafka;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationProducer {
+
+  private final KafkaTemplate<String, String> kafkaTemplate;
+
+  private static final String NOTIFICATION_TOPIC  = "notification-topic";
+
+  public void sendNotification(UUID notificationId){
+    String message = notificationId.toString();
+    kafkaTemplate.send(NOTIFICATION_TOPIC, message);
+  }
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/application/service/NotificationService.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/application/service/NotificationService.java
@@ -18,12 +18,12 @@ public class NotificationService {
   private final NotificationRepository notificationRepository;
 
   // 방송 시작 30분 전에 알림 예약
-  public NotificationCreateResponse createNotificationForLiveBroadcast(UUID userId, UUID hostId,
+  public NotificationCreateResponse createNotificationForLiveBroadcast(UUID userId, UUID broadcastId,
       LocalDateTime notificationTime) {
     Notification notification = Notification.builder()
         .userId(userId)
         .type(NotificationType.LIVE_BROADCAST)
-        .targetId(hostId)
+        .targetId(broadcastId)
         .message("방송이 30분 후에 시작됩니다.")  // 알림 메시지
         .isSent(false)  // 초기 상태는 알림 미전송
         .sentAt(notificationTime) // 알림전송 시간

--- a/client/notification/src/main/java/com/live_commerce/notification/application/service/NotificationService.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/application/service/NotificationService.java
@@ -1,0 +1,66 @@
+package com.live_commerce.notification.application.service;
+
+import com.live_commerce.notification.domain.model.Notification;
+import com.live_commerce.notification.domain.model.NotificationType;
+import com.live_commerce.notification.domain.repository.NotificationRepository;
+import com.live_commerce.notification.presentation.dto.response.NotificationCreateResponse;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+  private final NotificationRepository notificationRepository;
+
+  // 방송 시작 30분 전에 알림 예약
+  public NotificationCreateResponse createNotificationForLiveBroadcast(UUID userId, UUID hostId,
+      LocalDateTime notificationTime) {
+    Notification notification = Notification.builder()
+        .userId(userId)
+        .type(NotificationType.LIVE_BROADCAST)
+        .targetId(hostId)
+        .message("방송이 30분 후에 시작됩니다.")  // 알림 메시지
+        .isSent(false)  // 초기 상태는 알림 미전송
+        .sentAt(notificationTime) // 알림전송 시간
+        .scheduledAt(null)  // 실제 알림 전송 시간
+        .build();
+
+    try {
+      // 4. 알림 저장
+      notificationRepository.save(notification);
+      return NotificationCreateResponse.from(notification);
+    } catch (Exception e) {
+      // 5. 예외 발생 시 로깅 및 예외 던지기
+      log.error("알림 저장 중 오류 발생: ", e);
+      throw new RuntimeException("알림 저장에 실패했습니다. 다시 시도해주세요.");
+    }
+  }
+
+  public void sendNotification(UUID notificationId) {
+    Notification notification = notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new RuntimeException("알림을 찾을 수 없습니다."));
+
+    // 여기에 알림 전송 로직 (슬랙, Firebase, 이메일 등) 추가
+    // 예: FirebasePushService.send(notification.getMessage());
+
+    try {
+      // 알림 전송 후 알림 상태 업데이트
+      Notification updatedNotification = notification.updateIsSent();
+      notificationRepository.save(updatedNotification);
+    } catch (Exception e) {
+      // 알림 상태 업데이트 중 오류 발생
+      log.error("알림 상태 업데이트 중 오류 발생: ", e);
+      throw new RuntimeException("알림 상태 업데이트에 실패했습니다. 다시 시도해주세요.");
+    }
+  }
+
+  public Notification getNotification(UUID notificationId) {
+    return notificationRepository.findById(notificationId)
+        .orElseThrow(() -> new RuntimeException("알림을 찾을 수 없습니다."));
+  }
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/domain/model/BaseEntity.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/domain/model/BaseEntity.java
@@ -1,0 +1,48 @@
+package com.live_commerce.notification.domain.model;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+  @CreatedBy
+  @Column(updatable = false)
+  private String createdBy;
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedBy
+  private String updatedBy;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt;
+
+  private String deletedBy;
+
+  private LocalDateTime deletedAt;
+
+  private Boolean deletedStatus = false;
+
+  public void markAsDeleted(String deletedBy){
+    if(this.deletedStatus){
+      throw new IllegalStateException("Already deleted");
+    }
+    this.deletedStatus = true;
+    this.deletedBy = deletedBy;
+    this.deletedAt = LocalDateTime.now();
+  }
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/domain/model/Notification.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/domain/model/Notification.java
@@ -1,0 +1,57 @@
+package com.live_commerce.notification.domain.model;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@Getter
+@Table(name = "p_notifications")
+@NoArgsConstructor
+public class Notification extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private UUID id;
+
+  private UUID userId;
+
+  @Enumerated(EnumType.STRING)
+  private NotificationType type;
+
+  private UUID targetId;
+
+  private String message;
+
+  private boolean isSent = false; // 전송 여부
+
+  private LocalDateTime sentAt ; // 알림 전송 시간
+
+  private LocalDateTime scheduledAt; // 실제 알림 전송 시간
+
+  public Notification updateIsSent() {
+    return Notification.builder()
+        .id(this.id)
+        .userId(this.userId)
+        .type(this.type)
+        .targetId(this.targetId)
+        .message(this.message)
+        .isSent(true)
+        .sentAt(LocalDateTime.now())
+        .scheduledAt(this.scheduledAt)
+        .build();
+  }
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/domain/model/NotificationType.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/domain/model/NotificationType.java
@@ -1,0 +1,5 @@
+package com.live_commerce.notification.domain.model;
+
+public enum NotificationType {
+  LIVE_BROADCAST, PRODUCT_RESTOCK
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/domain/repository/NotificationRepository.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/domain/repository/NotificationRepository.java
@@ -1,0 +1,9 @@
+package com.live_commerce.notification.domain.repository;
+
+import com.live_commerce.notification.domain.model.Notification;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, UUID> {
+
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/infrastructure/config/KafkaConfig.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,26 @@
+package com.live_commerce.notification.infrastructure.config;
+
+import com.fasterxml.jackson.databind.ser.std.StringSerializer;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+public class KafkaConfig {
+
+  @Bean
+  public KafkaTemplate<String, String> kafkaTemplate() {
+    Map<String , Object> producerProps = new HashMap<>();
+    producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+    ProducerFactory<String, String> producerFactory = new DefaultKafkaProducerFactory<>(producerProps);
+    return new KafkaTemplate<>(producerFactory);
+  }
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/infrastructure/exception/GlobalExceptionHandler.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/infrastructure/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.live_commerce.notification.infrastructure.exception;
+
+import com.live_commerce.notification.presentation.common.ApiResponse;
+import javax.naming.AuthenticationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(AuthenticationException.class)
+  public ResponseEntity<ApiResponse<String>> handleAuthenticationException(AuthenticationException ex) {
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ApiResponse<>("인증이 필요합니다.", null));
+  }
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/presentation/controller/NotificationController.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/presentation/controller/NotificationController.java
@@ -1,0 +1,31 @@
+package com.live_commerce.notification.presentation.controller;
+
+import com.live_commerce.notification.application.service.NotificationService;
+import com.live_commerce.notification.infrastructure.common.ResponseUtil;
+import com.live_commerce.notification.presentation.common.ApiResponse;
+import com.live_commerce.notification.presentation.dto.request.NotificationCreateRequest;
+import com.live_commerce.notification.presentation.dto.response.NotificationCreateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+  private final NotificationService notificationService;
+
+  // 방송 시작 30분 전에 알림을 예약하는 API
+  @PostMapping("/create-for-broadcast")
+  public ResponseEntity<ApiResponse<NotificationCreateResponse>> createNotificationForLiveBroadcast(
+      @RequestBody NotificationCreateRequest request) {
+    NotificationCreateResponse response = notificationService.createNotificationForLiveBroadcast(
+        request.userId(),
+        request.hostId(),
+        request.notificationTime()
+    );
+
+    return ResponseUtil.success(response);
+  }
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/presentation/controller/NotificationController.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/presentation/controller/NotificationController.java
@@ -22,7 +22,7 @@ public class NotificationController {
       @RequestBody NotificationCreateRequest request) {
     NotificationCreateResponse response = notificationService.createNotificationForLiveBroadcast(
         request.userId(),
-        request.hostId(),
+        request.broadcastId(),
         request.notificationTime()
     );
 

--- a/client/notification/src/main/java/com/live_commerce/notification/presentation/dto/request/NotificationCreateRequest.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/presentation/dto/request/NotificationCreateRequest.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 public record NotificationCreateRequest(
     UUID userId,
-    UUID hostId,
+    UUID broadcastId,
     LocalDateTime notificationTime
 ) {
 }

--- a/client/notification/src/main/java/com/live_commerce/notification/presentation/dto/request/NotificationCreateRequest.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/presentation/dto/request/NotificationCreateRequest.java
@@ -1,0 +1,11 @@
+package com.live_commerce.notification.presentation.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record NotificationCreateRequest(
+    UUID userId,
+    UUID hostId,
+    LocalDateTime notificationTime
+) {
+}

--- a/client/notification/src/main/java/com/live_commerce/notification/presentation/dto/response/NotificationCreateResponse.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/presentation/dto/response/NotificationCreateResponse.java
@@ -1,0 +1,30 @@
+package com.live_commerce.notification.presentation.dto.response;
+
+import com.live_commerce.notification.domain.model.Notification;
+import com.live_commerce.notification.domain.model.NotificationType;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record NotificationCreateResponse(
+    UUID id,
+    UUID userId,
+    NotificationType type,
+    UUID targetId,
+    String message,
+    boolean isSent,
+    LocalDateTime sentAt,
+    LocalDateTime scheduledAt
+) {
+  public static NotificationCreateResponse from(Notification notification) {
+    return new NotificationCreateResponse(
+        notification.getId(),
+        notification.getUserId(),
+        notification.getType(),
+        notification.getTargetId(),
+        notification.getMessage(),
+        notification.isSent(),
+        notification.getSentAt(),
+        notification.getScheduledAt()
+    );
+  }
+}

--- a/client/notification/src/main/resources/application.yml
+++ b/client/notification/src/main/resources/application.yml
@@ -6,6 +6,14 @@ spring:
   config:
     import: "configserver:http://localhost:18080"
 
+  kafka:
+    bootstrap-servers: localhost:9092  # 카프카 브로커 URL
+    consumer:
+      group-id: notification-group  # 소비자 그룹 ID (필요에 따라 설정)
+    producer:
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+
 server:
   port: 0
 eureka:
@@ -20,6 +28,8 @@ management:
     web:
       exposure:
         include: refresh
+
+# 카프카 설정 추가
 
 
 #springdoc:


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [ ] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 방송 시작 30분 전에 알림을 예약하는 API 구현

* **세부 내용**
  * 추후 라이브 방송 생성 메서드에서 feignClient로 해당 api를 호출하면 됨.  

## 💡 추가 설명

* 현재 라이브 방송을 구독 및 예약 알림 신청 기능이 없어 단순 알림 로직만 구현되어 있음. 
* 리팩터링 시 방송 구독 알림 신청 기능 고려할 예정
* 

## 📚 참고 자료 (선택 사항)
![image](https://github.com/user-attachments/assets/ad56f3ad-271d-46e3-87f4-0143dd0f7865)

* 관련 자료 링크
