### PR TITLE
feat: 재고 확인 기능 구현 (KAN-51) + 상품 동시성 처리

### DIFF
--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/model/BaseEntity.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/domain/model/BaseEntity.java
@@ -35,7 +35,8 @@ public abstract class BaseEntity{
 
     private String deletedBy;
 
-    private Boolean deletedStatus;
+    @Column(nullable = false)
+    private boolean deletedStatus;
 
     protected BaseEntity() {
         this.deletedStatus = false;

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/product/ExternalProductResponseDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/product/ExternalProductResponseDto.java
@@ -1,9 +1,7 @@
 package com.live_commerce.livebroadcast.infrastructure.client.product;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.UUID;
 
 public record ExternalProductResponseDto (
-        @JsonProperty("id") UUID productId
+        UUID productId
 ) {}

--- a/client/product/build.gradle
+++ b/client/product/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 	implementation 'org.springframework.session:spring-session-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// redisson
+	implementation 'org.redisson:redisson:3.45.1'
+
 	// security
 	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	//implementation 'io.jsonwebtoken:jjwt:0.12.6'

--- a/client/product/build.gradle
+++ b/client/product/build.gradle
@@ -75,6 +75,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/dto/InventoryCheckQuantityRequestDto.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/dto/InventoryCheckQuantityRequestDto.java
@@ -1,0 +1,9 @@
+package com.live_commerce.product.inventory.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record InventoryCheckQuantityRequestDto (
+        @NotNull(message = "상품 id를 입력해주세요") UUID productId
+){ }

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/dto/InventoryCheckQuantityResponseDto.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/dto/InventoryCheckQuantityResponseDto.java
@@ -1,0 +1,6 @@
+package com.live_commerce.product.inventory.application.dto;
+
+public record InventoryCheckQuantityResponseDto(
+        int availableQuantity
+){
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/dto/InventoryCheckRequestDto.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/dto/InventoryCheckRequestDto.java
@@ -1,0 +1,11 @@
+package com.live_commerce.product.inventory.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record InventoryCheckRequestDto (
+        @NotNull(message = "상품 id를 입력해주세요") UUID productId,
+        @NotNull(message = "재고 수량을 입력해주세요") int orderQuantity
+) {
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/dto/InventoryCheckResponseDto.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/dto/InventoryCheckResponseDto.java
@@ -1,0 +1,8 @@
+package com.live_commerce.product.inventory.application.dto;
+
+import java.util.UUID;
+
+public record InventoryCheckResponseDto (
+        boolean orderAvailable
+) {
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/exception/InventoryExceptionCode.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/exception/InventoryExceptionCode.java
@@ -12,7 +12,9 @@ public enum InventoryExceptionCode implements ExceptionCode {
 
   NOT_FOUND(HttpStatus.NOT_FOUND, "재고 정보가 없습니다."),
   PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다."),
-  INVENTORY_OUT_OF_STOCK(HttpStatus.CONFLICT, "재고가 부족합니다.");
+  INVENTORY_OUT_OF_STOCK(HttpStatus.CONFLICT, "재고가 부족합니다."),
+  LOCK_ACQUISITION_FAILED(HttpStatus.TOO_MANY_REQUESTS, "현재 처리 중입니다. 잠시 후 다시 시도해주세요."),
+  LOCK_TIME_OUT(HttpStatus.REQUEST_TIMEOUT, "요청 시간이 초과되었습니다. 다시 시도해주세요.");
 
 
   private final HttpStatus httpStatus;

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/mapper/InventoryMapper.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/mapper/InventoryMapper.java
@@ -1,9 +1,13 @@
 package com.live_commerce.product.inventory.application.mapper;
 
+import com.live_commerce.product.inventory.application.dto.InventoryCheckQuantityResponseDto;
+import com.live_commerce.product.inventory.application.dto.InventoryCheckResponseDto;
 import com.live_commerce.product.inventory.application.dto.InventoryCreateRequestDto;
 import com.live_commerce.product.inventory.application.dto.InventoryResponseDto;
 import com.live_commerce.product.inventory.domain.model.Inventory;
+import org.springframework.stereotype.Component;
 
+@Component
 public class InventoryMapper {
 
     public static Inventory createDtoToEntity(InventoryCreateRequestDto dto) {
@@ -26,4 +30,13 @@ public class InventoryMapper {
                 entity.getInventoryStatus()
         );
     }
+
+    public static InventoryCheckQuantityResponseDto toCheckQuantityDto(Inventory inventory) {
+        return new InventoryCheckQuantityResponseDto(inventory.getAvailableQuantity());
+    }
+
+    public static InventoryCheckResponseDto toCheckResponseDto(boolean orderable) {
+        return new InventoryCheckResponseDto(orderable);
+    }
+
 }

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryService.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryService.java
@@ -3,15 +3,20 @@ package com.live_commerce.product.inventory.application.service;
 import com.live_commerce.product.inventory.application.dto.InventoryCreateRequestDto;
 import com.live_commerce.product.inventory.application.dto.InventoryResponseDto;
 import com.live_commerce.product.inventory.application.mapper.InventoryMapper;
+import com.live_commerce.product.inventory.application.validation.InventoryValidator;
 import com.live_commerce.product.inventory.domain.exception.InventoryException;
 import com.live_commerce.product.inventory.domain.model.Inventory;
 import com.live_commerce.product.inventory.domain.repository.InventoryRepository;
 import com.live_commerce.product.product.domain.repository.ProductRepository;
+import com.live_commerce.product.product.infrastructure.redisson.DistributedLock;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +24,8 @@ public class InventoryService {
 
     private final InventoryRepository inventoryRepository;
     private final ProductRepository productRepository;
+    private final InventoryValidator inventoryValidator;
+    private final RedissonClient redissonClient;
 
     @Transactional
     public InventoryResponseDto createInventory(InventoryCreateRequestDto requestDto) {
@@ -43,23 +50,26 @@ public class InventoryService {
         return InventoryMapper.entityToDto(inventory);
     }
 
+    @DistributedLock(key = "#productId")
     @Transactional
     public void decreaseInventory(UUID productId, int quantity) {
-        System.out.println("productId: " + productId);
+        inventoryValidator.validateExistsAndAvailableOrThrow(productId, quantity);
 
-        Inventory inventory = inventoryRepository.findByProductIdAndDeletedStatusFalse(productId)
-                .orElseThrow(InventoryException::forInventoryNotFound);
-
-        inventory.decrease(quantity);
-
+        int updated = inventoryRepository.decreaseInventoryAtomically(productId, quantity);
+        if (updated == 0) {
+            throw InventoryException.forInventoryOutOfStock();
+        }
     }
 
+    @DistributedLock(key = "#productId")
     @Transactional
     public void increaseInventory(UUID productId, int quantity) {
-        Inventory inventory = inventoryRepository.findByProductIdAndDeletedStatusFalse(productId)
-                .orElseThrow(InventoryException::forInventoryNotFound);
+        inventoryValidator.validateExistsOrThrow(productId);
 
-        inventory.increase(quantity);
+        int updated = inventoryRepository.increaseInventoryAtomically(productId, quantity);
+        if (updated == 0) {
+            throw InventoryException.forInventoryNotFound();
+        }
     }
 
     public boolean isSoldOut(UUID productId) {

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryService.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryService.java
@@ -1,23 +1,23 @@
 package com.live_commerce.product.inventory.application.service;
 
-import com.live_commerce.product.inventory.application.dto.InventoryCreateRequestDto;
-import com.live_commerce.product.inventory.application.dto.InventoryResponseDto;
+import com.live_commerce.product.inventory.application.dto.*;
 import com.live_commerce.product.inventory.application.mapper.InventoryMapper;
 import com.live_commerce.product.inventory.application.validation.InventoryValidator;
 import com.live_commerce.product.inventory.domain.exception.InventoryException;
 import com.live_commerce.product.inventory.domain.model.Inventory;
 import com.live_commerce.product.inventory.domain.repository.InventoryRepository;
 import com.live_commerce.product.product.domain.repository.ProductRepository;
-import com.live_commerce.product.product.infrastructure.redisson.DistributedLock;
+import com.live_commerce.product.inventory.infrastructure.redisson.DistributedLock;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.redisson.api.RLock;
+import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class InventoryService {
@@ -25,7 +25,7 @@ public class InventoryService {
     private final InventoryRepository inventoryRepository;
     private final ProductRepository productRepository;
     private final InventoryValidator inventoryValidator;
-    private final RedissonClient redissonClient;
+
 
     @Transactional
     public InventoryResponseDto createInventory(InventoryCreateRequestDto requestDto) {
@@ -53,8 +53,6 @@ public class InventoryService {
     @DistributedLock(key = "#productId")
     @Transactional
     public void decreaseInventory(UUID productId, int quantity) {
-        inventoryValidator.validateExistsAndAvailableOrThrow(productId, quantity);
-
         int updated = inventoryRepository.decreaseInventoryAtomically(productId, quantity);
         if (updated == 0) {
             throw InventoryException.forInventoryOutOfStock();
@@ -64,8 +62,6 @@ public class InventoryService {
     @DistributedLock(key = "#productId")
     @Transactional
     public void increaseInventory(UUID productId, int quantity) {
-        inventoryValidator.validateExistsOrThrow(productId);
-
         int updated = inventoryRepository.increaseInventoryAtomically(productId, quantity);
         if (updated == 0) {
             throw InventoryException.forInventoryNotFound();
@@ -81,7 +77,17 @@ public class InventoryService {
         return inventory.getQuantity() <= 0;
     }
 
+    public InventoryCheckQuantityResponseDto checkInventoryQuantity(InventoryCheckQuantityRequestDto requestDto) {
+        Inventory inventory = inventoryValidator.validateAndGetActiveInventory(requestDto.productId());
+        return InventoryMapper.toCheckQuantityDto(inventory);
+    }
 
 
-
+    public InventoryCheckResponseDto checkOrderableInventory(InventoryCheckRequestDto requestDto) {
+        boolean orderable = inventoryValidator.checkOrderable(
+                requestDto.productId(),
+                requestDto.orderQuantity()
+        );
+        return InventoryMapper.toCheckResponseDto(orderable);
+    }
 }

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/validation/InventoryValidator.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/validation/InventoryValidator.java
@@ -1,4 +1,44 @@
 package com.live_commerce.product.inventory.application.validation;
 
+import com.live_commerce.product.inventory.domain.exception.InventoryException;
+import com.live_commerce.product.inventory.domain.model.Inventory;
+import com.live_commerce.product.inventory.domain.repository.InventoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
 public class InventoryValidator {
+
+    private final InventoryRepository inventoryRepository;
+
+    // "재고 존재 여부"를 검증하고, 재고 엔티티를 리턴함
+    public Inventory validateAndGetActiveInventory(UUID productId) {
+        return inventoryRepository.findByProductIdAndDeletedStatusFalse(productId)
+                .orElseThrow(InventoryException::forInventoryNotFound);
+    }
+
+    // 이미 조회된 인벤토리에 대해 수량이 충분한지 검증만 수행
+    public void validateAvailableQuantityOrThrow(Inventory inventory, int quantity) {
+        if (inventory.getAvailableQuantity() < quantity) {
+            throw InventoryException.forInventoryOutOfStock();
+        }
+    }
+
+    // "존재 + 수량"을 동시에 검증 (서비스에 필요한 통합 메서드)
+    public void validateExistsAndAvailableOrThrow(UUID productId, int quantity) {
+        Inventory inventory = validateAndGetActiveInventory(productId);
+        validateAvailableQuantityOrThrow(inventory, quantity);
+    }
+
+    // 존재 여부만 검증 (increase 용도)
+    public void validateExistsOrThrow(UUID productId) {
+        boolean exists = inventoryRepository.findByProductIdAndDeletedStatusFalse(productId).isPresent();
+        if (!exists) {
+            throw InventoryException.forInventoryNotFound();
+        }
+    }
 }
+

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/validation/InventoryValidator.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/validation/InventoryValidator.java
@@ -33,12 +33,17 @@ public class InventoryValidator {
         validateAvailableQuantityOrThrow(inventory, quantity);
     }
 
-    // 존재 여부만 검증 (increase 용도)
+    // 존재 여부만 검증
     public void validateExistsOrThrow(UUID productId) {
         boolean exists = inventoryRepository.findByProductIdAndDeletedStatusFalse(productId).isPresent();
         if (!exists) {
             throw InventoryException.forInventoryNotFound();
         }
+    }
+
+    public boolean checkOrderable(UUID productId, int quantity) {
+        validateExistsOrThrow(productId);
+        return inventoryRepository.existsOrderableInventory(productId, quantity);
     }
 }
 

--- a/client/product/src/main/java/com/live_commerce/product/inventory/domain/exception/InventoryException.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/domain/exception/InventoryException.java
@@ -21,4 +21,11 @@ public class InventoryException extends CustomException {
     }
 
 
+    public static InventoryException forLockAcquisitionFailed() {
+        return new InventoryException(InventoryExceptionCode.LOCK_ACQUISITION_FAILED);
+    }
+
+    public static InventoryException forLockTimeout() {
+        return new InventoryException(InventoryExceptionCode.LOCK_TIME_OUT);
+    }
 }

--- a/client/product/src/main/java/com/live_commerce/product/inventory/domain/model/BaseEntity.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/domain/model/BaseEntity.java
@@ -35,7 +35,8 @@ public abstract class BaseEntity {
 
     private String deletedBy;
 
-    private Boolean deletedStatus;
+    @Column(nullable = false)
+    private boolean deletedStatus;
 
     protected BaseEntity() {
         this.deletedStatus = false;

--- a/client/product/src/main/java/com/live_commerce/product/inventory/domain/repository/InventoryRepository.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/domain/repository/InventoryRepository.java
@@ -11,6 +11,7 @@ public interface InventoryRepository {
     <S extends Inventory> S save(S inventory);
     Optional<Inventory> findByInventoryIdAndDeletedStatusFalse(UUID id);
     Optional<Inventory> findByProductIdAndDeletedStatusFalse(UUID productId);
+    boolean existsOrderableInventory(UUID productId, int quantity);
 
     int decreaseInventoryAtomically(UUID productId, int quantity);
     int increaseInventoryAtomically(UUID productId, int quantity);

--- a/client/product/src/main/java/com/live_commerce/product/inventory/domain/repository/InventoryRepository.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/domain/repository/InventoryRepository.java
@@ -1,6 +1,7 @@
 package com.live_commerce.product.inventory.domain.repository;
 
 import com.live_commerce.product.inventory.domain.model.Inventory;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -10,4 +11,7 @@ public interface InventoryRepository {
     <S extends Inventory> S save(S inventory);
     Optional<Inventory> findByInventoryIdAndDeletedStatusFalse(UUID id);
     Optional<Inventory> findByProductIdAndDeletedStatusFalse(UUID productId);
+
+    int decreaseInventoryAtomically(UUID productId, int quantity);
+    int increaseInventoryAtomically(UUID productId, int quantity);
 }

--- a/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/config/RedissonConfig.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/config/RedissonConfig.java
@@ -1,0 +1,30 @@
+package com.live_commerce.product.inventory.infrastructure.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.redis.port}")
+    private int redisPort;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+        RedissonClient redisson = null;
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(REDISSON_HOST_PREFIX + redisHost + ":" + redisPort);
+        redisson = Redisson.create(config);
+        return redisson;
+    }
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redisson/DistributedLock.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redisson/DistributedLock.java
@@ -1,4 +1,4 @@
-package com.live_commerce.product.product.infrastructure.redisson;
+package com.live_commerce.product.inventory.infrastructure.redisson;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redisson/DistributedLockAspect.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redisson/DistributedLockAspect.java
@@ -1,4 +1,4 @@
-package com.live_commerce.product.product.infrastructure.redisson;
+package com.live_commerce.product.inventory.infrastructure.redisson;
 
 
 import com.live_commerce.product.inventory.domain.exception.InventoryException;

--- a/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/repository/JpaInventoryRepository.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/repository/JpaInventoryRepository.java
@@ -17,6 +17,16 @@ public interface JpaInventoryRepository extends JpaRepository<Inventory, UUID>, 
 
     Optional<Inventory> findByProductIdAndDeletedStatusFalse(UUID productId);
 
+    @Query("""
+    SELECT CASE WHEN COUNT(i) > 0 THEN true ELSE false END
+    FROM Inventory i
+    WHERE i.productId = :productId
+      AND i.availableQuantity >= :quantity
+      AND i.deletedStatus = false
+""")
+    boolean existsOrderableInventory(@Param("productId") UUID productId,
+                                     @Param("quantity") int quantity);
+
     @Modifying(clearAutomatically = true)
     @Query("""
         UPDATE Inventory i

--- a/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/repository/JpaInventoryRepository.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/repository/JpaInventoryRepository.java
@@ -4,6 +4,9 @@ package com.live_commerce.product.inventory.infrastructure.repository;
 import com.live_commerce.product.inventory.domain.model.Inventory;
 import com.live_commerce.product.inventory.domain.repository.InventoryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -13,4 +16,32 @@ public interface JpaInventoryRepository extends JpaRepository<Inventory, UUID>, 
     Optional<Inventory> findByInventoryIdAndDeletedStatusFalse(UUID inventoryId);
 
     Optional<Inventory> findByProductIdAndDeletedStatusFalse(UUID productId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        UPDATE Inventory i
+        SET i.quantity = i.quantity - :quantity,
+            i.availableQuantity = i.availableQuantity - :quantity
+        WHERE i.productId = :productId
+          AND i.deletedStatus = false
+          AND i.availableQuantity >= :quantity
+    """)
+    int decreaseInventoryAtomically(
+            @Param("productId") UUID productId,
+            @Param("quantity") int quantity
+    );
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+        UPDATE Inventory i
+        SET i.quantity = i.quantity + :quantity,
+            i.availableQuantity = i.availableQuantity + :quantity
+        WHERE i.productId = :productId
+          AND i.deletedStatus = false
+    """)
+    int increaseInventoryAtomically(
+            @Param("productId") UUID productId,
+            @Param("quantity") int quantity
+    );
+
 }

--- a/client/product/src/main/java/com/live_commerce/product/inventory/presentation/controller/InventoryController.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/presentation/controller/InventoryController.java
@@ -1,10 +1,7 @@
 package com.live_commerce.product.inventory.presentation.controller;
 
 
-import com.live_commerce.product.inventory.application.dto.InventoryCreateRequestDto;
-import com.live_commerce.product.inventory.application.dto.InventoryDecreaseRequestDto;
-import com.live_commerce.product.inventory.application.dto.InventoryIncreaseRequestDto;
-import com.live_commerce.product.inventory.application.dto.InventoryResponseDto;
+import com.live_commerce.product.inventory.application.dto.*;
 import com.live_commerce.product.inventory.application.service.InventoryService;
 import com.live_commerce.product.inventory.infrastructure.common.ResponseUtil;
 import com.live_commerce.product.inventory.presentation.common.ApiResponse;
@@ -44,6 +41,20 @@ public class InventoryController {
     public ResponseEntity<ApiResponse<String>> increaseInventory(@Valid @RequestBody InventoryIncreaseRequestDto requestDto) {
         inventoryService.increaseInventory(requestDto.productId(), requestDto.quantity());
         return ResponseUtil.success("재고가 복원되었습니다.");
+    }
+
+    // 재고 총 수량 확인용 - 임시
+    @GetMapping("/checkquantity")
+    public ResponseEntity<ApiResponse<InventoryCheckQuantityResponseDto>> checkInventoryQuantity(@Valid @RequestBody InventoryCheckQuantityRequestDto requestDto) {
+        InventoryCheckQuantityResponseDto response = inventoryService.checkInventoryQuantity(requestDto);
+        return ResponseUtil.success(response);
+    }
+
+    // 주문 가능 재고 확인용
+    @GetMapping("/checkorderable")
+    public ResponseEntity<ApiResponse<InventoryCheckResponseDto>> checkOrderableInventory(@Valid @RequestBody InventoryCheckRequestDto requestDto) {
+        InventoryCheckResponseDto response = inventoryService.checkOrderableInventory(requestDto);
+        return ResponseUtil.success(response);
     }
 
 

--- a/client/product/src/main/java/com/live_commerce/product/product/domain/model/BaseEntity.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/domain/model/BaseEntity.java
@@ -35,7 +35,8 @@ public abstract class BaseEntity {
 
     private String deletedBy;
 
-    private Boolean deletedStatus;
+    @Column(nullable = false)
+    private boolean deletedStatus;
 
     protected BaseEntity() {
         this.deletedStatus = false;

--- a/client/product/src/main/java/com/live_commerce/product/product/domain/model/Product.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/domain/model/Product.java
@@ -29,6 +29,7 @@ public class Product extends BaseEntity{
 
     private Integer price;
 
+    @Enumerated(EnumType.STRING)
     private ProductCategory category;
 
     @Enumerated(EnumType.STRING)

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/exception/GlobalExceptionHandler.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/exception/GlobalExceptionHandler.java
@@ -1,11 +1,15 @@
 package com.live_commerce.product.product.infrastructure.exception;
 
+import com.live_commerce.product.inventory.domain.exception.InventoryException;
 import com.live_commerce.product.product.application.exception.CustomException;
 import com.live_commerce.product.product.infrastructure.common.ResponseUtil;
 import com.live_commerce.product.product.presentation.common.ApiResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/redisson/DistributedLock.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/redisson/DistributedLock.java
@@ -1,0 +1,16 @@
+package com.live_commerce.product.product.infrastructure.redisson;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+    String key();
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+    long waitTime() default 5L;
+    long leaseTime() default 3L;
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/redisson/DistributedLockAspect.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/redisson/DistributedLockAspect.java
@@ -1,0 +1,38 @@
+package com.live_commerce.product.product.infrastructure.redisson;
+
+
+import com.live_commerce.product.inventory.domain.exception.InventoryException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DistributedLockAspect {
+    private static final String REDISSON_LOCK_PREFIX = "LOCK:";
+    private final RedissonClient redissonClient;
+
+    @Around("@annotation(distributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint, DistributedLock distributedLock) throws Throwable {
+        String key = REDISSON_LOCK_PREFIX + distributedLock.key();
+        RLock rLock = redissonClient.getLock(key);
+        boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+        if (!available) {
+            throw InventoryException.forLockAcquisitionFailed();
+        }
+
+        try {
+            return joinPoint.proceed();
+        } finally {
+            rLock.unlock();
+        }
+    }
+
+}

--- a/client/product/src/main/resources/application.yml
+++ b/client/product/src/main/resources/application.yml
@@ -1,29 +1,24 @@
 spring:
   application:
     name: product
-
----
-spring:
+  profiles:
+    active: dev
   config:
-    activate:
-      on-profile: dev
     import: "configserver:http://localhost:18080"
 
 server:
   port: 0
+
 eureka:
   client:
     service-url:
       defaultZone: http://localhost:19090/eureka/
-
-message: "default message" # config server를 통과하지 않을 때
 
 management:
   endpoints:
     web:
       exposure:
         include: refresh
-
 
 
 #springdoc:
@@ -35,11 +30,3 @@ management:
 #  api-docs:
 #    enabled: true
 #    path: /v3/api-docs/user
-
-
----
-spring:
-  config:
-    activate:
-      on-profile: test
-    import: "optional:"

--- a/client/product/src/main/resources/application.yml
+++ b/client/product/src/main/resources/application.yml
@@ -1,9 +1,12 @@
 spring:
   application:
     name: product
-  profiles:
-    active: dev
+
+---
+spring:
   config:
+    activate:
+      on-profile: dev
     import: "configserver:http://localhost:18080"
 
 server:
@@ -22,6 +25,7 @@ management:
         include: refresh
 
 
+
 #springdoc:
 #  swagger-ui:
 #    enabled: true
@@ -31,3 +35,11 @@ management:
 #  api-docs:
 #    enabled: true
 #    path: /v3/api-docs/user
+
+
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+    import: "optional:"

--- a/client/product/src/test/java/com/live_commerce/product/inventory/InventoryServiceTest.java
+++ b/client/product/src/test/java/com/live_commerce/product/inventory/InventoryServiceTest.java
@@ -1,0 +1,132 @@
+package com.live_commerce.product.inventory;
+
+
+import com.live_commerce.product.inventory.application.service.InventoryService;
+import com.live_commerce.product.inventory.domain.model.Inventory;
+import com.live_commerce.product.inventory.domain.model.InventoryStatus;
+import com.live_commerce.product.inventory.domain.repository.InventoryRepository;
+import com.live_commerce.product.inventory.infrastructure.repository.JpaInventoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class InventoryServiceTest {
+
+    private static final UUID PRODUCT_ID = UUID.fromString("a8e5b7f9-bc53-4b3d-a2d2-d2513fa44b57");
+    private static final int INITIAL_QUANTITY = 100;
+
+    @Autowired
+    private InventoryService inventoryService;
+
+    @Autowired
+    private InventoryRepository inventoryRepository;
+
+    @Autowired
+    private JpaInventoryRepository jpaInventoryRepository;
+
+    @BeforeEach
+    @Rollback(false)
+    void setUp() {
+        if (inventoryRepository.findByProductIdAndDeletedStatusFalse(PRODUCT_ID).isEmpty()) {
+            Inventory inventory = Inventory.create(
+                    PRODUCT_ID,
+                    INITIAL_QUANTITY,
+                    0,
+                    INITIAL_QUANTITY,
+                    InventoryStatus.AVAILABLE
+            );
+            inventoryRepository.save(inventory);
+        }
+    }
+
+    @Test
+    void 동시_재고감소_테스트() throws InterruptedException {
+
+        System.out.println("=== BEFORE TEST ===");
+        jpaInventoryRepository.findAll().forEach(i ->
+                System.out.println("재고 있음: " + i.getProductId() + ", 삭제 상태: " + i.isDeletedStatus()));
+
+        int threadCount = 10;
+        int decreaseAmountPerThread = 1;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    inventoryService.decreaseInventory(PRODUCT_ID, decreaseAmountPerThread);
+                } catch (Exception e) {
+                    System.out.println("예외 발생: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(); // 모든 스레드 종료까지 대기
+
+        // 이후 재고 수량 검증
+        Inventory inventory = inventoryRepository.findByProductIdAndDeletedStatusFalse(PRODUCT_ID)
+                .orElseThrow(() -> new RuntimeException("재고가 존재하지 않습니다."));
+
+        assertEquals(
+                INITIAL_QUANTITY - (threadCount * decreaseAmountPerThread),
+                inventory.getAvailableQuantity()
+        );
+    }
+
+    @Test
+    void 재고초과요청시_예외발생_테스트() throws InterruptedException {
+        System.out.println("=== BEFORE OVER-REQUEST TEST ===");
+        jpaInventoryRepository.findAll().forEach(i ->
+                System.out.println("재고 있음: " + i.getProductId() + ", 삭제 상태: " + i.isDeletedStatus()));
+
+        int threadCount = 150; // 초기 재고 100보다 더 많은 요청
+        int decreaseAmountPerThread = 1;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    inventoryService.decreaseInventory(PRODUCT_ID, decreaseAmountPerThread);
+                } catch (Exception e) {
+                    failCount.incrementAndGet(); // 실패 카운트 증가
+                    System.out.println("예외 발생: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Inventory inventory = inventoryRepository.findByProductIdAndDeletedStatusFalse(PRODUCT_ID)
+                .orElseThrow(() -> new RuntimeException("재고가 존재하지 않습니다."));
+
+        System.out.println("최종 재고: " + inventory.getAvailableQuantity());
+        System.out.println("실패 요청 수: " + failCount.get());
+
+        assertEquals(0, inventory.getAvailableQuantity()); // 재고는 0이어야 하고
+        assertEquals(threadCount - INITIAL_QUANTITY, failCount.get()); // 실패 수 == 초과 요청 수
+    }
+
+
+}

--- a/client/product/src/test/resources/application-test.yml
+++ b/client/product/src/test/resources/application-test.yml
@@ -1,0 +1,33 @@
+spring:
+  application:
+    name: product
+  cloud:
+    config:
+      enabled: false
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;DATABASE_TO_UPPER=false;INIT=CREATE SCHEMA IF NOT EXISTS inventories\;CREATE SCHEMA IF NOT EXISTS products
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+  redis:
+    host: localhost
+    port: 6379
+
+eureka:
+  client:
+    enabled: false
+
+logging:
+  level:
+    root: INFO
+    com.live_commerce: DEBUG
+    org.redisson: DEBUG
+    org.hibernate.SQL: DEBUG

--- a/server/config/src/main/resources/config-repo/product-dev.yml
+++ b/server/config/src/main/resources/config-repo/product-dev.yml
@@ -19,3 +19,6 @@ spring:
     username: postgres
     password: 8dostore
     driver-class-name: org.postgresql.Driver
+  redis:
+    host: localhost
+    port: 6379


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 주문 서비스에서 재고 확인할 수 있게, 재고확인 api 와 재고 수량 확인 api 를 구현하였습니다.
  * 상품 동시성처리를 위해 Redisson 분산락을 적용하였습니다. (테스트 필요) -> 테스트작업중에 어쩌다보니 올라감... 죄송합니다..

* **세부 내용**
  * 주문할 상품 정보(상품 id, 이름, 가격, 상태 등)는 (GET /api/v1/products/{productId}) 호출
  * 주문할 상품 재고확인은 (GET /api/v1/inventories/checkorderable) 호출
  * 상품 재고 감소는 (POST /api/v1/inventories/decrease) 호출
  * 테스트용 상품 재고 총수량 확인 (GET /api/v1/inventories/checkquantity) 호출 하시면 됩니다.
  * 호출 api는 `productId`, `orderQuantity` 를 requestBody에 보내주시면 됩니다
  * 게이트웨이에서 inventory 서비스에 대한 라우팅 설정이 아직 반영되지 않았습니다.  추후 해당 부분은 제가 수정해놓겠습니다.  
  * 현재 inventory 호출이 안 되는 경우, 말씀해주시면 빠르게 확인하겠습니다! (라이브방송, 상품 마찬가지)

## 💡 추가 설명

![image](https://github.com/user-attachments/assets/9097eee8-2fe1-4207-bfc4-0b716f230df4)
재고 수량 확인용 (GET http://localhost:19070/api/v1/inventories/checkquantity)

![image](https://github.com/user-attachments/assets/9deac45d-cc47-489a-9f4b-76bc23793f72)
주문 가능 수량 확인용 (GET http://localhost:19070/api/v1/inventories/checkorderable)
## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
