### PR TITLE
feat: 라이브방송, 상품 서비스 시큐리티 설정 추가 및 FeignClient 인증 연동 적용 (KAN-52)

### DIFF
--- a/client/livebroadcast/build.gradle
+++ b/client/livebroadcast/build.gradle
@@ -53,8 +53,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// security
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
-	//implementation 'io.jsonwebtoken:jjwt:0.12.6'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt:0.12.6'
 
 	// postgresql
 	implementation 'org.postgresql:postgresql:42.7.5'

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/request/BroadcastProductConnectDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/dto/request/BroadcastProductConnectDto.java
@@ -3,8 +3,5 @@ package com.live_commerce.livebroadcast.application.dto.request;
 import java.util.UUID;
 
 public record BroadcastProductConnectDto(
-        UUID liveBroadcastId,
         UUID productId
-) {
-
-}
+) { }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/mapper/BroadcastProductMapper.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/mapper/BroadcastProductMapper.java
@@ -6,6 +6,8 @@ import com.live_commerce.livebroadcast.domain.model.BroadcastProduct;
 import com.live_commerce.livebroadcast.domain.model.LiveBroadcast;
 import com.live_commerce.livebroadcast.infrastructure.client.product.ExternalProductResponseDto;
 
+import java.util.UUID;
+
 public class BroadcastProductMapper {
 
     public static BroadcastProductResponseDto entityToDto(BroadcastProduct entity) {
@@ -16,13 +18,12 @@ public class BroadcastProductMapper {
         );
     }
 
-    public static BroadcastProduct connectDtoToEntity(BroadcastProductConnectDto dto) {
-        return BroadcastProduct.create(dto.liveBroadcastId(), dto.productId());
+    public static BroadcastProduct connectDtoToEntity(UUID broadcastId, BroadcastProductConnectDto dto) {
+        return BroadcastProduct.create(broadcastId, dto.productId());
     }
 
-    public static BroadcastProductConnectDto toConnectDto(LiveBroadcast broadcast, ExternalProductResponseDto productDto) {
+    public static BroadcastProductConnectDto toConnectDto(ExternalProductResponseDto productDto) {
         return new BroadcastProductConnectDto(
-                broadcast.getLiveBroadcastId(),
                 productDto.productId()
         );
     }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/service/BroadcastProductService.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/service/BroadcastProductService.java
@@ -38,20 +38,21 @@ public class BroadcastProductService {
     private final LiveBroadcastValidator liveBroadcastValidator;
     private final ProductValidator productValidator;
 
-    private final ProductClient productClient;
 
 
     @Transactional
     public BroadcastProductResponseDto connectBroadcastProduct(UUID liveBroadcastId, BroadcastProductConnectDto requestDto) {
 
+        System.out.println("🟡 서비스 진입: connectBroadcastProduct 호출됨");
         LiveBroadcast broadcast = liveBroadcastValidator.validateExists(liveBroadcastId);
+        System.out.println("✅ 라이브 방송 존재 확인 완료");
 
         ExternalProductResponseDto productDto = productValidator.getValidProductOrThrow(requestDto.productId());
 
         liveBroadcastValidator.validateNotConnected(broadcast.getLiveBroadcastId(), productDto.productId());
 
-        BroadcastProductConnectDto connectDto = BroadcastProductMapper.toConnectDto(broadcast, productDto);
-        BroadcastProduct broadcastProduct = BroadcastProductMapper.connectDtoToEntity(connectDto);
+        BroadcastProductConnectDto connectDto = BroadcastProductMapper.toConnectDto(productDto);
+        BroadcastProduct broadcastProduct = BroadcastProductMapper.connectDtoToEntity(broadcast.getLiveBroadcastId(), connectDto);
 
         broadcastProductRepository.save(broadcastProduct);
 
@@ -74,7 +75,7 @@ public class BroadcastProductService {
         List<ProductSummaryDto> productSummaries = productValidator.getValidProductsOrThrow(productIds.getContent());
 
         Map<UUID, ProductSummaryDto> summaryMap = productSummaries.stream()
-                .collect(Collectors.toMap(ProductSummaryDto::id, Function.identity()));
+                .collect(Collectors.toMap(ProductSummaryDto::productId, Function.identity()));
 
         List<BroadcastProductListResponseDto> content = productIds.getContent().stream()
                 .map(id -> {

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/validation/ProductValidator.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/application/validation/ProductValidator.java
@@ -19,17 +19,21 @@ public class ProductValidator {
     private final ProductClient productClient;
 
     public ExternalProductResponseDto getValidProductOrThrow(UUID productId) {
+        System.out.println("🔍 ProductValidator.getValidProductOrThrow 호출됨, productId: " + productId);
         try {
             ApiResponse<ExternalProductResponseDto> productResponse = productClient.getProduct(productId);
-
+            System.out.println("✅ FeignClient 응답 수신 완료");
             if (productResponse.getData() == null) {
+                System.out.println("❌ 상품 없음");
                 throw LiveBroadcastException.forExternalProductNotFound();
             }
 
             return productResponse.getData();
         } catch (FeignException.NotFound e) {
+            System.out.println("❌ Feign 404 오류 발생");
             throw LiveBroadcastException.forExternalProductNotFound();
         } catch (FeignException e) {
+            System.out.println("❌ Feign 예외 발생: " + e.getMessage());
             throw new RuntimeException("상품 서비스 호출 실패", e);
         }
     }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/company/CompanyClient.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/company/CompanyClient.java
@@ -8,9 +8,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.UUID;
 
-@FeignClient(name = "company")
+@FeignClient(name = "company", url = "http://localhost:19091", path = "/api/v1/companies")
 public interface CompanyClient {
 
-    @GetMapping("/api/v1/companies/{id}")
-    ApiResponse<ExternalCompanyResponseDto> getCompany(@PathVariable("id") UUID id);
+    @GetMapping("/{companyId}")
+    ApiResponse<ExternalCompanyResponseDto> getCompany(@PathVariable("companyId") UUID companyId);
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/company/ExternalCompanyResponseDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/company/ExternalCompanyResponseDto.java
@@ -5,5 +5,5 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 
 public record ExternalCompanyResponseDto (
-        @JsonProperty("id") UUID companyId
+        UUID companyId
 ) {}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/product/ProductClient.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/product/ProductClient.java
@@ -1,6 +1,7 @@
 package com.live_commerce.livebroadcast.infrastructure.client.product;
 
 import com.live_commerce.livebroadcast.infrastructure.client.company.ExternalCompanyResponseDto;
+import com.live_commerce.livebroadcast.infrastructure.config.FeignLogConfig;
 import com.live_commerce.livebroadcast.presentation.common.ApiResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,13 +12,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import java.util.List;
 import java.util.UUID;
 
-@FeignClient(name = "product")
+@FeignClient(name = "product", url = "http://localhost:19091", path = "/api/v1/products",
+        configuration = FeignLogConfig.class)
 public interface ProductClient {
 
-    @GetMapping("/api/v1/products/{id}")
-    ApiResponse<ExternalProductResponseDto> getProduct(@PathVariable("id") UUID id);
+    @GetMapping("/{productId}")
+    ApiResponse<ExternalProductResponseDto> getProduct(@PathVariable("productId") UUID productId);
 
-    @PostMapping("/api/v1/products/bulk")
+    @PostMapping("/bulk")
     ApiResponse<List<ProductSummaryDto>> getProducts(@RequestBody List<UUID> productIds);
 
 }

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/product/ProductSummaryDto.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/client/product/ProductSummaryDto.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 
 public record ProductSummaryDto (
-        UUID id,
+        UUID productId,
         String name,
         Integer price
 ) {

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/config/FeignConfig.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/config/FeignConfig.java
@@ -13,5 +13,7 @@ public class FeignConfig {
         return new ErrorDecoder.Default();
     }
 
+
+
 }
 

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/config/FeignLogConfig.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/config/FeignLogConfig.java
@@ -1,0 +1,14 @@
+package com.live_commerce.livebroadcast.infrastructure.config;
+
+import feign.Logger;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FeignLogConfig {
+    @Bean
+    public Logger.Level feignLoggerLevel() {
+        return Logger.Level.FULL;
+    }
+}
+

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/AuditorAwareImpl.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/AuditorAwareImpl.java
@@ -1,0 +1,29 @@
+package com.live_commerce.livebroadcast.infrastructure.security;
+
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+	@Override
+	public Optional<String> getCurrentAuditor() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !authentication.isAuthenticated()) {
+			return Optional.empty();
+		}
+
+		Object principal = authentication.getPrincipal();
+		if (principal instanceof RequestUserDetails userDetails) {
+			return Optional.of(userDetails.getUsername());
+		}
+
+		return Optional.empty();
+	}
+}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/AuthenticationFilter.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/AuthenticationFilter.java
@@ -37,6 +37,11 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 			return;
 		}
 
+		String token = request.getHeader("Authorization");
+		if (token != null && token.startsWith("Bearer ")) {
+			token = token.substring(7); // "Bearer " 제거
+		}
+
 		// 요청 헤더에서 사용자 정보 추출
 		String userIdHeader = request.getHeader("X-User-Id");
 		String username = request.getHeader("X-User-Username");
@@ -64,7 +69,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 
 		// 인증 정보 설정
 		UsernamePasswordAuthenticationToken authentication =
-			new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
+			new UsernamePasswordAuthenticationToken(userDetails, token, authorities);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		// 필터 체인으로 넘김

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/AuthenticationFilter.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/AuthenticationFilter.java
@@ -1,0 +1,73 @@
+package com.live_commerce.livebroadcast.infrastructure.security;
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class AuthenticationFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+
+		String requestUri = request.getRequestURI();
+
+		// 인증이 필요 없는 경로는 필터를 통과시킴
+		if ((requestUri.startsWith("/api/v1/auth/") &&
+			!requestUri.startsWith("/api/v1/auth/approve") &&
+			!requestUri.equals("/api/v1/auth/logout")) ||
+			requestUri.startsWith("/swagger-ui/") ||
+			requestUri.startsWith("/v3/api-docs") ||
+			requestUri.startsWith("/actuator")) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		// 요청 헤더에서 사용자 정보 추출
+		String userIdHeader = request.getHeader("X-User-Id");
+		String username = request.getHeader("X-User-Username");
+		String role = request.getHeader("X-User-Role");
+
+		if (userIdHeader == null || username == null || role == null) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			return;
+		}
+
+		UUID userId;
+		try {
+			userId = UUID.fromString(userIdHeader);
+		} catch (IllegalArgumentException e) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			return;
+		}
+
+		if (!role.startsWith("ROLE_")) {
+			role = "ROLE_" + role;
+		}
+
+		List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
+		UserDetails userDetails = new RequestUserDetails(userId, username, authorities);
+
+		// 인증 정보 설정
+		UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		// 필터 체인으로 넘김
+		filterChain.doFilter(request, response);
+	}
+}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/FeignClientInterceptor.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/FeignClientInterceptor.java
@@ -1,0 +1,33 @@
+package com.live_commerce.livebroadcast.infrastructure.security;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Configuration
+public class FeignClientInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate requestTemplate) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.getCredentials() instanceof String token) {
+            String userId = authentication.getName(); // userId 가져오기
+            String role = authentication.getAuthorities().stream()
+                    .findFirst()
+                    .map(GrantedAuthority::getAuthority)
+                    .orElse("ROLE_USER"); // 기본값 ROLE_USER
+
+            System.out.println("🚀 FeignClientInterceptor 적용됨 - Authorization 헤더 추가: " + token);
+            requestTemplate.header("Authorization", "Bearer " + token);
+            requestTemplate.header("X-Hub-User", userId);
+            requestTemplate.header("X-Hub-Role", role);
+        } else {
+            System.out.println("🚨 FeignClientInterceptor 적용 실패 - SecurityContext에서 토큰을 찾을 수 없음");
+        }
+    }
+
+}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/RequestUserDetails.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/RequestUserDetails.java
@@ -1,0 +1,41 @@
+package com.live_commerce.livebroadcast.infrastructure.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.UUID;
+
+
+public class RequestUserDetails implements UserDetails {
+
+	private final UUID userId;
+	private final String username;
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	public RequestUserDetails(UUID userId, String username, Collection<? extends GrantedAuthority> authorities) {
+		this.userId = userId;
+		this.username = username;
+		this.authorities = authorities;
+	}
+
+	public UUID getUserId() {
+		return userId;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public String getUsername() {
+		return username;
+	}
+
+	@Override public String getPassword() { return null; }
+	@Override public boolean isAccountNonExpired() { return true; }
+	@Override public boolean isAccountNonLocked() { return true; }
+	@Override public boolean isCredentialsNonExpired() { return true; }
+	@Override public boolean isEnabled() { return true; }
+}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/SecurityConfig.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.live_commerce.livebroadcast.infrastructure.security;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final AuthenticationFilter authenticationFilter;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		// HTTP 보안 설정
+		http
+			.csrf((csrf) -> csrf.disable())  // CSRF 비활성화
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 상태를 사용하지 않음
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(
+					"/api/v1/auth/**", // 인증되지 않은 경로
+					"/swagger-ui/**",
+					"/v3/api-docs/**",
+					"/actuator/**"
+				).permitAll() // 인증 없이 접근 가능
+				.anyRequest().authenticated() // 그 외의 요청은 인증 필요
+			)
+			.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class); // 인증 필터 추가
+
+		return http.build();
+	}
+}

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/presentation/controller/BroadcastProductController.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/presentation/controller/BroadcastProductController.java
@@ -28,6 +28,7 @@ public class BroadcastProductController {
             @RequestBody BroadcastProductConnectDto requestDto,
             @PathVariable UUID broadcastId
     ) {
+        System.out.println("🚀 컨트롤러 진입: broadcastId=" + broadcastId + ", productId=" + requestDto.productId());
         BroadcastProductResponseDto responseDto = broadcastProductService.connectBroadcastProduct(broadcastId,requestDto);
         return ResponseUtil.success(responseDto);
     }

--- a/client/product/build.gradle
+++ b/client/product/build.gradle
@@ -56,8 +56,8 @@ dependencies {
 	implementation 'org.redisson:redisson:3.45.1'
 
 	// security
-	//implementation 'org.springframework.boot:spring-boot-starter-security'
-	//implementation 'io.jsonwebtoken:jjwt:0.12.6'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'io.jsonwebtoken:jjwt:0.12.6'
 
 	// postgresql
 	implementation 'org.postgresql:postgresql:42.7.5'

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/exception/InventoryExceptionCode.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/exception/InventoryExceptionCode.java
@@ -13,8 +13,7 @@ public enum InventoryExceptionCode implements ExceptionCode {
   NOT_FOUND(HttpStatus.NOT_FOUND, "재고 정보가 없습니다."),
   PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "상품이 존재하지 않습니다."),
   INVENTORY_OUT_OF_STOCK(HttpStatus.CONFLICT, "재고가 부족합니다."),
-  LOCK_ACQUISITION_FAILED(HttpStatus.TOO_MANY_REQUESTS, "현재 처리 중입니다. 잠시 후 다시 시도해주세요."),
-  LOCK_TIME_OUT(HttpStatus.REQUEST_TIMEOUT, "요청 시간이 초과되었습니다. 다시 시도해주세요.");
+  LOCK_ACQUISITION_FAILED(HttpStatus.TOO_MANY_REQUESTS, "현재 처리 중입니다. 잠시 후 다시 시도해주세요.");
 
 
   private final HttpStatus httpStatus;

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryService.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryService.java
@@ -8,10 +8,8 @@ import com.live_commerce.product.inventory.domain.model.Inventory;
 import com.live_commerce.product.inventory.domain.repository.InventoryRepository;
 import com.live_commerce.product.product.domain.repository.ProductRepository;
 import com.live_commerce.product.inventory.infrastructure.redisson.DistributedLock;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -89,5 +87,22 @@ public class InventoryService {
                 requestDto.orderQuantity()
         );
         return InventoryMapper.toCheckResponseDto(orderable);
+    }
+
+    @DistributedLock(key = "#productId", waitTime = 1, leaseTime = 2) // 강제 제한
+    public void lockForTesting(UUID productId, int holdSeconds) {
+        try {
+            Thread.sleep(holdSeconds * 1000L);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Transactional
+    public void decreaseInventoryWithoutLock(UUID productId, int quantity) {
+        Inventory inventory = inventoryRepository.findByProductIdAndDeletedStatusFalse(productId)
+                .orElseThrow(InventoryException::forInventoryNotFound);
+
+        inventory.decrease(quantity);
     }
 }

--- a/client/product/src/main/java/com/live_commerce/product/inventory/domain/exception/InventoryException.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/domain/exception/InventoryException.java
@@ -25,7 +25,4 @@ public class InventoryException extends CustomException {
         return new InventoryException(InventoryExceptionCode.LOCK_ACQUISITION_FAILED);
     }
 
-    public static InventoryException forLockTimeout() {
-        return new InventoryException(InventoryExceptionCode.LOCK_TIME_OUT);
-    }
 }

--- a/client/product/src/main/java/com/live_commerce/product/inventory/domain/model/Inventory.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/domain/model/Inventory.java
@@ -7,10 +7,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.UuidGenerator;
 
 import java.util.UUID;
 
+@Slf4j
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -52,12 +54,16 @@ public class Inventory extends BaseEntity{
     }
 
     public void decrease(int quantity) {
+        log.info("감소 시도: 요청 수량={}, 현재 수량={}", quantity, this.availableQuantity);
         if (this.availableQuantity < quantity) {
+            log.warn("재고 부족: 요청 수량={}, 현재 수량={}", quantity, this.availableQuantity);
             throw InventoryException.forInventoryOutOfStock();
         }
 
         this.availableQuantity -= quantity;
         this.quantity -= quantity;
+
+        log.info("재고 차감 성공: 남은 수량={}", this.availableQuantity);
 
         if (this.availableQuantity <= 0) {
             this.inventoryStatus = InventoryStatus.OUT_OF_STOCK;

--- a/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redis/InventoryRedisService.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redis/InventoryRedisService.java
@@ -1,0 +1,28 @@
+package com.live_commerce.product.inventory.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class InventoryRedisService {
+
+    private final RedisTemplate<String, String>  redisTemplate;
+
+    public void setAvailableQuantity(UUID productId, int quantity) {
+        redisTemplate.opsForValue().set(RedisKey.availableQuantity(productId), String.valueOf(quantity));
+    }
+
+    public Optional<Integer> getAvailableQuantity(UUID productId) {
+        String value = redisTemplate.opsForValue().get(RedisKey.availableQuantity(productId));
+        return Optional.ofNullable(value).map(Integer::parseInt);
+    }
+
+    public void deleteAvailableQuantity(UUID productId) {
+        redisTemplate.delete(RedisKey.availableQuantity(productId));
+    }
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redis/RedisKey.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redis/RedisKey.java
@@ -1,0 +1,12 @@
+package com.live_commerce.product.inventory.infrastructure.redis;
+
+import java.util.UUID;
+
+public class RedisKey {
+
+    public static final String INVENTORY_PREFIX = "inventory:";
+
+    public static String availableQuantity(UUID productId) {
+        return INVENTORY_PREFIX + productId + ":available";
+    }
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/presentation/controller/InventoryController.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/presentation/controller/InventoryController.java
@@ -57,5 +57,11 @@ public class InventoryController {
         return ResponseUtil.success(response);
     }
 
+    @PostMapping("/decrease/no-lock")
+    public ResponseEntity<ApiResponse<String>> decreaseInventoryNoLock(@Valid @RequestBody InventoryDecreaseRequestDto requestDto) {
+        inventoryService.decreaseInventoryWithoutLock(requestDto.productId(), requestDto.quantity());
+        return ResponseUtil.success("재고가 정상적으로 차감되었습니다.");
+    }
+
 
 }

--- a/client/product/src/main/java/com/live_commerce/product/product/application/mapper/ProductMapper.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/application/mapper/ProductMapper.java
@@ -15,13 +15,13 @@ import java.util.UUID;
 public class ProductMapper {
 
     public static Product createDtoToEntity(ProductCreateRequestDto requestDto, UUID companyId) {
-        return Product.builder()
-                .name(requestDto.name())
-                .description(requestDto.description())
-                .price(requestDto.price())
-                .category(requestDto.category())
-                .companyId(companyId)
-                .build();
+        return Product.create(
+                companyId,
+                requestDto.name(),
+                requestDto.description(),
+                requestDto.price(),
+                requestDto.category()
+        );
     }
 
     public static ProductCreateResponseDto entityToCreateDto(Product entity) {

--- a/client/product/src/main/java/com/live_commerce/product/product/application/validation/ProductValidator.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/application/validation/ProductValidator.java
@@ -15,6 +15,7 @@ public class ProductValidator {
     private final ProductRepository productRepository;
 
     public Product validateAndFindProduct(UUID productId) {
+        System.out.println("🔥🔥🔥🔥 validateAndFindProduct 호출됨: " + productId);
         return productRepository.findByProductIdAndDeletedStatusFalse(productId)
                 .orElseThrow(ProductException::forProductNotFound);
     }

--- a/client/product/src/main/java/com/live_commerce/product/product/domain/model/Product.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/domain/model/Product.java
@@ -36,8 +36,7 @@ public class Product extends BaseEntity{
     private ProductStatus productStatus;
 
     @Builder
-    private Product(UUID productId, UUID companyId, String name, String description, Integer price, ProductCategory category) {
-        this.productId = productId;
+    private Product(UUID companyId, String name, String description, Integer price, ProductCategory category) {
         this.companyId = companyId;
         this.name = name;
         this.description = description;

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/client/CompanyClient.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/client/CompanyClient.java
@@ -7,11 +7,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.UUID;
 
-@FeignClient(name = "company")
+@FeignClient(name = "company", url = "http://localhost:19091", path = "/api/v1/companies")
 public interface CompanyClient {
 
-    @GetMapping("/api/v1/companies/{id}")
-    ApiResponse<ExternalCompanyResponseDto> getCompany(@PathVariable("id") UUID id);
+    @GetMapping("/{companyId}")
+    ApiResponse<ExternalCompanyResponseDto> getCompany(@PathVariable("companyId") UUID companyId);
 
 //    @GetMapping("/api/v1/companies/{id}")
 //    public ExternalCompanyResponseDto getCompany(@PathVariable UUID id) {

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/AuditorAwareImpl.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/AuditorAwareImpl.java
@@ -1,0 +1,29 @@
+package com.live_commerce.product.product.infrastructure.security;
+
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+	@Override
+	public Optional<String> getCurrentAuditor() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication == null || !authentication.isAuthenticated()) {
+			return Optional.empty();
+		}
+
+		Object principal = authentication.getPrincipal();
+		if (principal instanceof RequestUserDetails userDetails) {
+			return Optional.of(userDetails.getUsername());
+		}
+
+		return Optional.empty();
+	}
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/AuthenticationFilter.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/AuthenticationFilter.java
@@ -37,6 +37,11 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 			return;
 		}
 
+		String token = request.getHeader("Authorization");
+		if (token != null && token.startsWith("Bearer ")) {
+			token = token.substring(7); // "Bearer " 제거
+		}
+
 		// 요청 헤더에서 사용자 정보 추출
 		String userIdHeader = request.getHeader("X-User-Id");
 		String username = request.getHeader("X-User-Username");
@@ -64,7 +69,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 
 		// 인증 정보 설정
 		UsernamePasswordAuthenticationToken authentication =
-			new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
+			new UsernamePasswordAuthenticationToken(userDetails, token, authorities);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		// 필터 체인으로 넘김

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/AuthenticationFilter.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/AuthenticationFilter.java
@@ -1,0 +1,73 @@
+package com.live_commerce.product.product.infrastructure.security;
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class AuthenticationFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+
+		String requestUri = request.getRequestURI();
+
+		// 인증이 필요 없는 경로는 필터를 통과시킴
+		if ((requestUri.startsWith("/api/v1/auth/") &&
+			!requestUri.startsWith("/api/v1/auth/approve") &&
+			!requestUri.equals("/api/v1/auth/logout")) ||
+			requestUri.startsWith("/swagger-ui/") ||
+			requestUri.startsWith("/v3/api-docs") ||
+			requestUri.startsWith("/actuator")) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		// 요청 헤더에서 사용자 정보 추출
+		String userIdHeader = request.getHeader("X-User-Id");
+		String username = request.getHeader("X-User-Username");
+		String role = request.getHeader("X-User-Role");
+
+		if (userIdHeader == null || username == null || role == null) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			return;
+		}
+
+		UUID userId;
+		try {
+			userId = UUID.fromString(userIdHeader);
+		} catch (IllegalArgumentException e) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			return;
+		}
+
+		if (!role.startsWith("ROLE_")) {
+			role = "ROLE_" + role;
+		}
+
+		List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(role));
+		UserDetails userDetails = new RequestUserDetails(userId, username, authorities);
+
+		// 인증 정보 설정
+		UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		// 필터 체인으로 넘김
+		filterChain.doFilter(request, response);
+	}
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/FeignClientInterceptor.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/FeignClientInterceptor.java
@@ -1,0 +1,33 @@
+package com.live_commerce.product.product.infrastructure.security;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Configuration
+public class FeignClientInterceptor implements RequestInterceptor {
+
+    @Override
+    public void apply(RequestTemplate requestTemplate) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication != null && authentication.getCredentials() instanceof String token) {
+            String userId = authentication.getName(); // userId 가져오기
+            String role = authentication.getAuthorities().stream()
+                    .findFirst()
+                    .map(GrantedAuthority::getAuthority)
+                    .orElse("ROLE_USER"); // 기본값 ROLE_USER
+
+            System.out.println("🚀 FeignClientInterceptor 적용됨 - Authorization 헤더 추가: " + token);
+            requestTemplate.header("Authorization", "Bearer " + token);
+            requestTemplate.header("X-Hub-User", userId);
+            requestTemplate.header("X-Hub-Role", role);
+        } else {
+            System.out.println("🚨 FeignClientInterceptor 적용 실패 - SecurityContext에서 토큰을 찾을 수 없음");
+        }
+    }
+
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/RequestUserDetails.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/RequestUserDetails.java
@@ -1,0 +1,41 @@
+package com.live_commerce.product.product.infrastructure.security;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.UUID;
+
+
+public class RequestUserDetails implements UserDetails {
+
+	private final UUID userId;
+	private final String username;
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	public RequestUserDetails(UUID userId, String username, Collection<? extends GrantedAuthority> authorities) {
+		this.userId = userId;
+		this.username = username;
+		this.authorities = authorities;
+	}
+
+	public UUID getUserId() {
+		return userId;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
+	}
+
+	@Override
+	public String getUsername() {
+		return username;
+	}
+
+	@Override public String getPassword() { return null; }
+	@Override public boolean isAccountNonExpired() { return true; }
+	@Override public boolean isAccountNonLocked() { return true; }
+	@Override public boolean isCredentialsNonExpired() { return true; }
+	@Override public boolean isEnabled() { return true; }
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/SecurityConfig.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/security/SecurityConfig.java
@@ -1,0 +1,48 @@
+package com.live_commerce.product.product.infrastructure.security;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final AuthenticationFilter authenticationFilter;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		// HTTP 보안 설정
+		http
+			.csrf((csrf) -> csrf.disable())  // CSRF 비활성화
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 상태를 사용하지 않음
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(
+					"/api/v1/auth/**", // 인증되지 않은 경로
+					"/swagger-ui/**",
+					"/v3/api-docs/**",
+					"/actuator/**"
+				).permitAll() // 인증 없이 접근 가능
+				.anyRequest().authenticated() // 그 외의 요청은 인증 필요
+			)
+			.addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class); // 인증 필터 추가
+
+		return http.build();
+	}
+}

--- a/client/product/src/test/java/com/live_commerce/product/inventory/InventoryServiceTest.java
+++ b/client/product/src/test/java/com/live_commerce/product/inventory/InventoryServiceTest.java
@@ -2,6 +2,7 @@ package com.live_commerce.product.inventory;
 
 
 import com.live_commerce.product.inventory.application.service.InventoryService;
+import com.live_commerce.product.inventory.domain.exception.InventoryException;
 import com.live_commerce.product.inventory.domain.model.Inventory;
 import com.live_commerce.product.inventory.domain.model.InventoryStatus;
 import com.live_commerce.product.inventory.domain.repository.InventoryRepository;
@@ -128,5 +129,39 @@ public class InventoryServiceTest {
         assertEquals(threadCount - INITIAL_QUANTITY, failCount.get()); // 실패 수 == 초과 요청 수
     }
 
+
+    @Test
+    void 락획득실패_테스트() throws InterruptedException {
+        UUID productId = PRODUCT_ID;
+
+        CountDownLatch latch = new CountDownLatch(2);
+
+        // 1. 스레드1이 락을 잡고 오래 점유
+        new Thread(() -> {
+            try {
+                inventoryService.lockForTesting(productId, 5); // sleep 5초
+            } catch (Exception e) {
+                System.out.println("Thread1 예외: " + e.getMessage());
+            } finally {
+                latch.countDown();
+            }
+        }).start();
+
+        Thread.sleep(500); // 락 선점 보장
+
+        // 2. 스레드2가 락을 못잡고 실패
+        new Thread(() -> {
+            try {
+                inventoryService.lockForTesting(productId, 0); // 바로 실패해야함
+            } catch (InventoryException e) {
+                System.out.println("Thread2 예외 발생: " + e.getMessage());
+                assertEquals("현재 처리 중입니다. 잠시 후 다시 시도해주세요.", e.getMessage());
+            } finally {
+                latch.countDown();
+            }
+        }).start();
+
+        latch.await();
+    }
 
 }

--- a/server/config/src/main/resources/config-repo/gateway-dev.yml
+++ b/server/config/src/main/resources/config-repo/gateway-dev.yml
@@ -67,7 +67,7 @@ spring:
         - id: product
           uri: lb://product
           predicates:
-            - Path=/api/v1/products/**, /api-docs-product
+            - Path=/api/v1/products/**, /api/v1/inventories/**, /api-docs-product
 
         - id: user
           uri: lb://user


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 라이브방송, 상품 서비스 시큐리티 설정 추가 및 feignclient 통신 정상확인

* **세부 내용**
  * 라이브방송, 상품 서비스에 시큐리티 설정을 적용하였습니다.
  * 시큐리티 설정 적용 후 타 서비스와 Feign Client 통신을 정상적으로 확인하였습니다. (라이브방송&업체, 라이브방송&상품)
  * 시큐리티 적용에는 `AuditorAwareImpl`, `AuthenticationFilter`, `FeignClientInterceptor`, `RequestUserDetails`, `SecurityConfig` 총 5개의 파일을 추가하였습니다.
  * FeignClient 통신을 위해 `AuthenticationFilter` 일부 코드에 수정이 필요하여 수정하였습니다. 
  * FeignClient 통신을 위해 `FeignClientInterceptor` 파일을 추가하였습니다.

## 💡 추가 설명

* FeignClientInterceptor -> Feign 요청 시 현재 SecurityContext의 인증 정보를 JWT로 변환하여 Authorization 헤더에 포함시키기 위한 인터셉터입니다.
* FeignClientInterceptor가 SecurityContextHolder의 인증 객체에서 credentials를 통해 token을 추출하는 구조이기 때문에, null로 설정 시 Authorization 헤더가 생성되지 않아 인증이 실패하였습니다. 이에 따라 인증 객체 생성 시 JWT token을 credentials로 함께 등록하도록 수정하였습니다.
* 인터셉터에서 token을 추출하는 방식 자체를 수정할 수도 있었지만, UserDetails 구현체에 token 필드를 추가해야 하는 부담이 있어, 간단히 credentials에 token을 설정하는 방식으로 AuthenticationFilter 코드만 최소한으로 수정하였습니다.

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
