### PR TITLE
feat: 결제 서비스와 주문 서비스 간의 Feign 통신부 구현 (KAN-56)

### DIFF
--- a/client/payment/src/main/java/com/live_commerce/payment/PaymentApplication.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/PaymentApplication.java
@@ -2,10 +2,12 @@ package com.live_commerce.payment;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class PaymentApplication {
 
 	public static void main(String[] args) {

--- a/client/payment/src/main/java/com/live_commerce/payment/application/service/PaymentService.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/application/service/PaymentService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.live_commerce.payment.application.dto.event.PaymentCancelEvent;
-import com.live_commerce.payment.application.dto.event.PaymentCompletedEvent;
 import com.live_commerce.payment.application.dto.request.PaymentApproveRequestDto;
 import com.live_commerce.payment.application.dto.request.PaymentReadyRequestDto;
 import com.live_commerce.payment.application.dto.request.PaymentRefundResponseDto;
@@ -28,8 +27,12 @@ import com.live_commerce.payment.application.port.KakaoPayClient;
 import com.live_commerce.payment.domain.model.Payment;
 import com.live_commerce.payment.domain.model.PaymentStatus;
 import com.live_commerce.payment.domain.repository.PaymentRepository;
+import com.live_commerce.payment.infrastructure.client.OrderClient;
 import com.live_commerce.payment.infrastructure.client.dto.KakaoPayApproveDto;
 import com.live_commerce.payment.infrastructure.client.dto.KakaoPayReadyDto;
+import com.live_commerce.payment.infrastructure.client.dto.PaymentCancelRequest;
+import com.live_commerce.payment.infrastructure.client.dto.PaymentFailRequest;
+import com.live_commerce.payment.infrastructure.client.dto.PaymentSuccessRequest;
 import com.live_commerce.payment.infrastructure.lock.DistributedLock;
 import com.live_commerce.payment.infrastructure.kafka.producer.PaymentCancelEventProducer;
 import com.live_commerce.payment.infrastructure.kafka.producer.PaymentSuccessEventProducer;
@@ -45,6 +48,8 @@ public class PaymentService {
 
 	private final PaymentRepository paymentRepository;
 	private final KakaoPayClient kakaoPayClient;
+	private final OrderClient orderClient;
+
 	private final RedissonClient redissonClient;
 	private final PaymentSuccessEventProducer paymentSuccessEventProducer;
 	private final PaymentCancelEventProducer paymentCancelEventProducer;
@@ -102,19 +107,44 @@ public class PaymentService {
 				new PaymentCancelEvent(payment.getOrderId(), payment.getId(), "KAKAO_API_FAIL")
 			);
 
+			// 주문 서비스에 결제 실패 알림
+			try {
+				orderClient.notifyPaymentFail(
+					payment.getOrderId(),
+					new PaymentFailRequest(false, "카카오페이 승인 실패")
+				);
+			} catch (Exception ex) {
+				log.warn("주문 서비스에 결제 실패 알림 전송 실패: {}", ex.getMessage());
+			}
+
+
 			throw new CustomException(PaymentExceptionCode.PAYMENT_APPROVE_FAIL);
 		}
 
 		// 3) 성공적으로 승인됐으면 상태 변경
 		payment.updateStatus(PaymentStatus.COMPLETED);
 
-		PaymentCompletedEvent event = new PaymentCompletedEvent(
-			payment.getOrderId(),
-			payment.getId(),
-			payment.getStatus().name(),
-			payment.getAmount().intValue()
-		);
-		paymentSuccessEventProducer.sendPaymentCompletedEvent(event);
+		// 주문 서비스에 결제 성공 알림
+		try {
+			PaymentSuccessRequest request = new PaymentSuccessRequest(
+				true,
+				"결제 처리 완료",
+				payment.getAmount()
+			);
+
+			orderClient.notifyPaymentSuccess(payment.getOrderId(), request);
+		} catch (Exception e) {
+			log.warn("주문 서비스에 결제 성공 알림 실패: {}", e.getMessage());
+		}
+
+		// 추후 오더 카프카 추가시 활성화
+		// PaymentCompletedEvent event = new PaymentCompletedEvent(
+		// 	payment.getOrderId(),
+		// 	payment.getId(),
+		// 	payment.getStatus().name(),
+		// 	payment.getAmount().intValue()
+		// );
+		// paymentSuccessEventProducer.sendPaymentCompletedEvent(event);
 
 		// 4) 응답 DTO 반환
 		return PaymentApproveResponseDto.from(approveDto);
@@ -178,6 +208,16 @@ public class PaymentService {
 		kakaoPayClient.requestKakaoPayCancel(payment.getTid(), payment.getAmount());
 		payment.updateStatus(PaymentStatus.REFUND);
 
+		try {
+			orderClient.notifyOrderCancel(
+				orderId,
+				new PaymentCancelRequest(false, "결제 취소 처리됨")
+			);
+		} catch (Exception e) {
+			log.warn("주문 서비스에 결제 취소 알림 실패: {}", e.getMessage());
+		}
+
+
 		return PaymentRefundResponseDto.from(payment);
 	}
 
@@ -190,6 +230,15 @@ public class PaymentService {
 		// 상태 확인: 아직 결제가 승인되지 않은 상태여야 함
 		if (payment.getStatus() != PaymentStatus.PENDING) {
 			throw new CustomException(PaymentExceptionCode.INVALID_STATUS);
+		}
+
+		try {
+			orderClient.notifyOrderCancel(
+				orderId,
+				new PaymentCancelRequest(false, "결제 취소 처리됨")
+			);
+		} catch (Exception e) {
+			log.warn("주문 서비스에 결제 취소 알림 실패: {}", e.getMessage());
 		}
 
 		payment.updateStatus(PaymentStatus.CANCELED);

--- a/client/payment/src/main/java/com/live_commerce/payment/infrastructure/client/OrderClient.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/infrastructure/client/OrderClient.java
@@ -1,0 +1,35 @@
+package com.live_commerce.payment.infrastructure.client;
+
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.live_commerce.payment.infrastructure.client.dto.PaymentCancelRequest;
+import com.live_commerce.payment.infrastructure.client.dto.PaymentFailRequest;
+import com.live_commerce.payment.infrastructure.client.dto.PaymentSuccessRequest;
+
+@FeignClient(name = "order", url = "http://localhost:19091", path = "/api/v1/orders")
+public interface OrderClient {
+
+	@PostMapping("/{orderId}/payment-success")
+	void notifyPaymentSuccess(
+		@PathVariable UUID orderId,
+		@RequestBody PaymentSuccessRequest request
+	);
+
+	@PostMapping("/{orderId}/payment-fail")
+	void notifyPaymentFail(
+		@PathVariable UUID orderId,
+		@RequestBody PaymentFailRequest request
+	);
+
+	@PostMapping("/{orderId}/payment-cancel")
+	void notifyOrderCancel(
+		@PathVariable UUID orderId,
+		@RequestBody PaymentCancelRequest request
+	);
+
+}

--- a/client/payment/src/main/java/com/live_commerce/payment/infrastructure/client/dto/PaymentCancelRequest.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/infrastructure/client/dto/PaymentCancelRequest.java
@@ -1,0 +1,6 @@
+package com.live_commerce.payment.infrastructure.client.dto;
+
+public record PaymentCancelRequest(
+	boolean success,
+	String message
+) {}

--- a/client/payment/src/main/java/com/live_commerce/payment/infrastructure/client/dto/PaymentFailRequest.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/infrastructure/client/dto/PaymentFailRequest.java
@@ -1,0 +1,6 @@
+package com.live_commerce.payment.infrastructure.client.dto;
+
+public record PaymentFailRequest(
+	boolean success,
+	String message
+) {}

--- a/client/payment/src/main/java/com/live_commerce/payment/infrastructure/client/dto/PaymentSuccessRequest.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/infrastructure/client/dto/PaymentSuccessRequest.java
@@ -1,0 +1,9 @@
+package com.live_commerce.payment.infrastructure.client.dto;
+
+import java.math.BigDecimal;
+
+public record PaymentSuccessRequest(
+	boolean success,
+	String message,
+	BigDecimal finalPaidPrice
+) {}

--- a/client/payment/src/main/java/com/live_commerce/payment/infrastructure/filter/AuthenticationFilter.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/infrastructure/filter/AuthenticationFilter.java
@@ -29,12 +29,19 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 		String requestUri = request.getRequestURI();
 
 		// 인증이 필요 없는 경로는 필터를 통과시킴
-		if ((requestUri.startsWith("/api/v1/auth/") && !requestUri.equals("/api/v1/auth/logout")) ||
+		if ((requestUri.startsWith("/api/v1/auth/") &&
+			!requestUri.startsWith("/api/v1/auth/approve") &&
+			!requestUri.equals("/api/v1/auth/logout")) ||
 			requestUri.startsWith("/swagger-ui/") ||
 			requestUri.startsWith("/v3/api-docs") ||
 			requestUri.startsWith("/actuator")) {
 			filterChain.doFilter(request, response);
 			return;
+		}
+
+		String token = request.getHeader("Authorization");
+		if (token != null && token.startsWith("Bearer ")) {
+			token = token.substring(7); // "Bearer " 제거
 		}
 
 		// 요청 헤더에서 사용자 정보 추출
@@ -64,7 +71,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 
 		// 인증 정보 설정
 		UsernamePasswordAuthenticationToken authentication =
-			new UsernamePasswordAuthenticationToken(userDetails, null, authorities);
+			new UsernamePasswordAuthenticationToken(userDetails, token, authorities);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 
 		// 필터 체인으로 넘김

--- a/client/payment/src/main/java/com/live_commerce/payment/infrastructure/security/FeignClientInterceptor.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/infrastructure/security/FeignClientInterceptor.java
@@ -1,0 +1,40 @@
+package com.live_commerce.payment.infrastructure.security;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Configuration
+public class FeignClientInterceptor implements RequestInterceptor {
+
+	@Override
+	public void apply(RequestTemplate requestTemplate) {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+		if (authentication != null && authentication.getCredentials() instanceof String token) {
+			String userId = authentication.getName();
+			String role = authentication.getAuthorities().stream()
+				.findFirst()
+				.map(GrantedAuthority::getAuthority)
+				.orElse("ROLE_USER");
+
+			String username = "";
+			Object principal = authentication.getPrincipal();
+
+			if (principal instanceof RequestUserDetails userDetails) {
+				username = userDetails.getUsername();
+			}
+
+			System.out.println("FeignClientInterceptor 적용됨 - Authorization 헤더 추가: " + token);
+			requestTemplate.header("Authorization", "Bearer " + token);
+			requestTemplate.header("X-User-Id", userId);
+			requestTemplate.header("X-User-Username", username);
+			requestTemplate.header("X-User-Role", role);
+		} else {
+			System.out.println("FeignClientInterceptor 적용 실패 - SecurityContext에서 토큰을 찾을 수 없음");
+		}
+	}
+}


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 결제 서비스에서 주문 서비스로의 FeignClient 통신 구현 (결제 성공/실패/취소)

* **세부 내용**
  * OrderClient 인터페이스 생성 및 세 가지 POST 요청 구현
    * /payment-success : 결제 성공 알림
    * /payment-fail : 결제 실패 알림
    * /payment-cancel : 결제 취소 알림
  * 각각의 요청에 대응하는 DTO(PaymentSuccessRequest, PaymentFailRequest, PaymentCancelRequest) 작성
  * PaymentService에서 결제 승인 로직 내에 Feign 요청 연동
  * FeignClientInterceptor를 통해 인증 헤더 전달 처리

## 💡 추가 설명

* 코드 리뷰 시 특별히 참고해야 할 부분이 있다면 언급해주세요.
* 궁금한 점이나 논의하고 싶은 내용이 있다면 작성해주세요.

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
