### PR TITLE
feat: AI 분석 결과 Slack DM 전송 기능 구현 (KAN-62)

### DIFF
--- a/client/ai/build.gradle
+++ b/client/ai/build.gradle
@@ -76,6 +76,10 @@ dependencies {
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	// webflux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 dependencyManagement {

--- a/client/ai/src/main/java/com/live_commerce/ai/application/service/AiService.java
+++ b/client/ai/src/main/java/com/live_commerce/ai/application/service/AiService.java
@@ -23,6 +23,7 @@ import com.live_commerce.ai.domain.repository.AiRepository;
 import com.live_commerce.ai.domain.prompt.PromptGenerator;
 import com.live_commerce.ai.infrastructure.client.GeminiServiceAdapter;
 import com.live_commerce.ai.infrastructure.security.RequestUserDetails;
+import com.live_commerce.ai.infrastructure.slack.SlackSender;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,11 +35,15 @@ public class AiService {
 	private final PromptGenerator promptGenerator;
 	private final GeminiServiceAdapter geminiServiceAdapter;
 	private final ObjectMapper objectMapper;
+	private final SlackSender slackSender;
 
 	private static final int MAX_CHAT_MESSAGES = 50;
 
 	@Value("${internal.secret}")
 	private String internalSecret;
+	@Value("${slack.admin-user-id}")
+	private String adminSlackUserId;
+
 
 	public AiCreateResponseDto analyze(AiAnalyzeRequestDto request, String providedSecret) {
 		if (!internalSecret.equals(providedSecret)) {
@@ -54,6 +59,11 @@ public class AiService {
 		String prompt = promptGenerator.generate(trimmed);
 		String response = generateResponse(prompt);
 		String requestPayloadJson = serializeRequest(request);
+
+		// TODO: 현재는 관리자용 슬랙 ID로만 알림 전송함
+		//       추후에 쇼호스트 계정으로 전송 기능 구현 예정
+		slackSender.sendMessage(adminSlackUserId,
+			"채팅 분석 완료\n\n" + response);
 
 		AI saved = aiRepository.save(AI.of(request.live_broadcast_id(), requestPayloadJson, response));
 		return AiCreateResponseDto.from(saved);

--- a/client/ai/src/main/java/com/live_commerce/ai/infrastructure/slack/SlackSender.java
+++ b/client/ai/src/main/java/com/live_commerce/ai/infrastructure/slack/SlackSender.java
@@ -1,0 +1,39 @@
+package com.live_commerce.ai.infrastructure.slack;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import org.springframework.http.HttpHeaders;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SlackSender {
+
+	@Value("${slack.bot-token}")
+	private String botToken;
+
+	private static final String SLACK_API_URL = "https://slack.com/api/chat.postMessage";
+
+	public void sendMessage(String slackUserId, String text) {
+		WebClient.create()
+			.post()
+			.uri(SLACK_API_URL)
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + botToken)
+			.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.bodyValue(Map.of(
+				"channel", slackUserId,
+				"text", text
+			))
+			.retrieve()
+			.bodyToMono(String.class)
+			.subscribe(response -> {
+				System.out.println("Slack 응답: " + response);
+			});
+	}
+}
+

--- a/server/config/src/main/resources/config-repo/ai-dev.yml
+++ b/server/config/src/main/resources/config-repo/ai-dev.yml
@@ -28,3 +28,7 @@ gemini:
 
 internal:
   secret: ${INTERNAL_SECRET}
+
+slack:
+  bot-token: ${SLACK_BOT_TOKEN}
+  admin-user-id: ${SLACK_ADMIN_USER_ID}


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * AI 분석 결과 Slack DM 전송 기능 구현

* **세부 내용**
  - `SlackSender` 유틸 컴포넌트 구현 (WebClient 기반)
  - Slack API 연동
    - 현재는 고정된 관리자 슬랙 ID로만 전송
    - 추후 방송 host → slackUserId 매핑 구조로 확장 예정

## 💡 추가 설명

* 코드 리뷰 시 특별히 참고해야 할 부분이 있다면 언급해주세요.
* 궁금한 점이나 논의하고 싶은 내용이 있다면 작성해주세요.

## 📚 참고 자료 (선택 사항)
<img width="999" alt="image" src="https://github.com/user-attachments/assets/92e3af31-4af8-455b-9e6b-0a8a409e95a4" />

* 관련 자료 링크
