### PR TITLE
test: 유저 도메인 테스트 및 삭제 유저 처리 로직 개선 (KAN-71)

### DIFF
--- a/client/user/build.gradle
+++ b/client/user/build.gradle
@@ -74,7 +74,11 @@ dependencies {
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
+	// MailSender
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// H2 DB
+	testRuntimeOnly 'com.h2database:h2'
 
 }
 

--- a/client/user/src/main/java/com/live_commerce/user/application/service/UserService.java
+++ b/client/user/src/main/java/com/live_commerce/user/application/service/UserService.java
@@ -33,7 +33,14 @@ public class UserService {
 	@Transactional(readOnly = true)
 	public UserGetResponseDto getUser(UUID userId, RequestUserDetails userDetails) {
 		validateUserGetPermission(userId, userDetails);
-		User user = findUserById(userId);
+
+		User user;
+		if (hasMasterRole(userDetails)) {
+			user = findUserEvenIfDeleted(userId); // 마스터는 삭제 유저도 조회 가능
+		} else {
+			user = findUserById(userId); // 일반 유저는 삭제 유저 조회 시 예외
+		}
+
 		return UserGetResponseDto.from(user);
 	}
 
@@ -57,9 +64,17 @@ public class UserService {
 	@Transactional
 	public UserUpdateResponseDto updateUser(UUID userId, UserUpdateRequestDto requestDto, RequestUserDetails userDetails) {
 		validateUserUpdatePermission(userId, requestDto, userDetails);
-		User user = findUserById(userId);
+
+		User user;
+		if (hasMasterRole(userDetails)) {
+			user = findUserEvenIfDeleted(userId); // 마스터는 삭제 유저도 수정 가능
+		} else {
+			user = findUserById(userId); // 일반 유저는 삭제 유저 수정 시 예외
+		}
+
 		String updatedPassword = requestDto.password() != null
-			? passwordEncoder.encode(requestDto.password()) : user.getPassword();
+			? passwordEncoder.encode(requestDto.password())
+			: user.getPassword();
 
 		user.updateUser(
 			updatedPassword,
@@ -107,6 +122,16 @@ public class UserService {
 	}
 
 	private User findUserById(UUID userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(UserExceptionCode.USER_NOT_FOUND));
+
+		if (user.isDeletedStatus()) {
+			throw new CustomException(UserExceptionCode.DELETED_USER);
+		}
+		return user;
+	}
+
+	private User findUserEvenIfDeleted(UUID userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new CustomException(UserExceptionCode.USER_NOT_FOUND));
 	}

--- a/client/user/src/main/java/com/live_commerce/user/application/service/UserService.java
+++ b/client/user/src/main/java/com/live_commerce/user/application/service/UserService.java
@@ -74,7 +74,7 @@ public class UserService {
 
 	@Transactional
 	public void deleteUser(UUID userId, RequestUserDetails userDetails) {
-		validateUserDeletePermission(userDetails);
+		validateUserDeletePermission(userId, userDetails);
 		User user = findUserById(userId);
 		user.markAsDeleted(userDetails.getUsername());
 	}
@@ -100,8 +100,8 @@ public class UserService {
 		}
 	}
 
-	private void validateUserDeletePermission(RequestUserDetails userDetails) {
-		if (!hasMasterRole(userDetails)) {
+	private void validateUserDeletePermission(UUID userId, RequestUserDetails userDetails) {
+		if (!isSelf(userId, userDetails) && !hasMasterRole(userDetails)) {
 			throw new CustomException(UserExceptionCode.FORBIDDEN);
 		}
 	}

--- a/client/user/src/test/java/com/live_commerce/user/application/service/AuthServiceTest.java
+++ b/client/user/src/test/java/com/live_commerce/user/application/service/AuthServiceTest.java
@@ -100,6 +100,25 @@ class AuthServiceTest {
 		verify(redisUtil).setDataExpire(startsWith("RT:"), eq("refresh-token"), anyLong());
 	}
 
+	@Test
+	@DisplayName("로그인 실패 - 탈퇴 유저")
+	void signIn_deletedUser() {
+		// Given
+		User user = User.of("user", "encoded", "email", "nick", true, UserRole.CUSTOMER, true);
+		user.markAsDeleted("admin");
+
+		when(userRepository.findByUsername("user")).thenReturn(Optional.of(user));
+		when(passwordEncoder.matches("password", "encoded")).thenReturn(true);
+
+		// When & Then
+		CustomException ex = catchThrowableOfType(
+			() -> authService.signIn(new UserSignInRequestDto("user", "password")),
+			CustomException.class
+		);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.DELETED_USER);
+	}
+
 	@DisplayName("토큰 재발급 성공")
 	@Test
 	void reissueToken_success() {
@@ -136,6 +155,92 @@ class AuthServiceTest {
 		verify(redisUtil).deleteData("RT:" + userId);
 	}
 
+	@Test
+	@DisplayName("아이디 찾기 성공")
+	void findUsername_success() {
+		// Given
+		String email = "user@email.com";
+		String expectedUsername = "testuser";
+		String inputCode = "123456";
+
+		User user = User.of(expectedUsername, "pw", email, "nick", true, UserRole.CUSTOMER, false);
+
+		when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+		when(redisUtil.getData(email)).thenReturn(inputCode);
+
+		// When
+		String username = authService.confirmFindUsernameCode(email, inputCode);
+
+		// Then
+		assertThat(username).isEqualTo(expectedUsername);
+		verify(redisUtil).deleteData(email);
+	}
+
+	@Test
+	@DisplayName("아이디 찾기 실패 - 인증코드 만료")
+	void findUsername_codeExpired() {
+		// Given
+		String email = "user@email.com";
+		when(redisUtil.getData(email)).thenReturn(null); // 없으면 만료
+
+		// When & Then
+		CustomException ex = catchThrowableOfType(() ->
+			authService.confirmFindUsernameCode(email, "123456"), CustomException.class);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.VERIFICATION_CODE_EXPIRED);
+	}
+
+	@Test
+	@DisplayName("아이디 찾기 실패 - 인증코드 불일치")
+	void findUsername_invalidCode() {
+		// Given
+		String email = "user@email.com";
+		when(redisUtil.getData(email)).thenReturn("actual-code");
+
+		// When & Then
+		CustomException ex = catchThrowableOfType(() ->
+			authService.confirmFindUsernameCode(email, "wrong-code"), CustomException.class);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.INVALID_VERIFICATION_CODE);
+	}
+
+	@Test
+	@DisplayName("아이디 찾기 실패 - 유저 없음")
+	void findUsername_userNotFound() {
+		// Given
+		String email = "user@email.com";
+		String inputCode = "123456";
+
+		when(redisUtil.getData(email)).thenReturn(inputCode);
+		when(userRepository.findByEmail(email)).thenReturn(Optional.empty());
+
+		// When & Then
+		CustomException ex = catchThrowableOfType(() ->
+			authService.confirmFindUsernameCode(email, inputCode), CustomException.class);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.USER_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("아이디 찾기 실패 - 탈퇴 유저")
+	void findUsername_deletedUser() {
+		// given
+		String email = "user@email.com";
+		String inputCode = "123456";
+
+		User user = User.of("deletedUser", "pw", email, "nick", true, UserRole.CUSTOMER, true);
+		user.markAsDeleted("test"); // 삭제 상태로 변경
+
+		when(userRepository.findByEmail(email)).thenReturn(Optional.of(user));
+		when(redisUtil.getData(email)).thenReturn(inputCode);
+
+		// when & then
+		CustomException ex = catchThrowableOfType(
+			() -> authService.confirmFindUsernameCode(email, inputCode), CustomException.class);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.DELETED_USER);
+	}
+
 	@DisplayName("임시 비밀번호 전송 성공")
 	@Test
 	void resetPasswordAndSendTempPassword_success() {
@@ -151,4 +256,24 @@ class AuthServiceTest {
 		verify(userRepository).findByUsernameAndEmail("user", "email");
 		verify(mailService).sendTemporaryPassword(eq("email"), any());
 	}
+
+	@Test
+	@DisplayName("임시 비밀번호 전송 실패 - 탈퇴 유저")
+	void resetPassword_deletedUser() {
+		// Given
+		User deletedUser = User.of("user", "pw", "email", "nickname", true, UserRole.CUSTOMER, true);
+		deletedUser.markAsDeleted("admin");
+
+		when(userRepository.findByUsernameAndEmail("user", "email"))
+			.thenReturn(Optional.of(deletedUser));
+
+		// When & Then
+		CustomException ex = catchThrowableOfType(
+			() -> authService.resetPasswordAndSendTempPassword("user", "email"),
+			CustomException.class
+		);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.DELETED_USER);
+	}
+
 }

--- a/client/user/src/test/java/com/live_commerce/user/application/service/AuthServiceTest.java
+++ b/client/user/src/test/java/com/live_commerce/user/application/service/AuthServiceTest.java
@@ -1,0 +1,154 @@
+package com.live_commerce.user.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.live_commerce.user.application.dto.auth.request.*;
+import com.live_commerce.user.application.dto.auth.response.*;
+import com.live_commerce.user.application.exception.*;
+import com.live_commerce.user.domain.model.*;
+import com.live_commerce.user.domain.repository.UserRepository;
+import com.live_commerce.user.infrastructure.client.CouponClient;
+import com.live_commerce.user.infrastructure.common.JwtUtil;
+import com.live_commerce.user.infrastructure.common.RedisUtil;
+
+import io.jsonwebtoken.Claims;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class AuthServiceTest {
+
+	@Autowired private AuthService authService;
+
+	@MockitoBean
+	private UserRepository userRepository;
+	@MockitoBean
+	private PasswordEncoder passwordEncoder;
+	@MockitoBean
+	private JwtUtil jwtUtil;
+	@MockitoBean
+	private RedisUtil redisUtil;
+	@MockitoBean
+	private MailService mailService;
+	@MockitoBean
+	private CouponClient couponClient;
+
+	@DisplayName("회원가입 성공")
+	@Test
+	void signUp_success() {
+		// Given
+		UserSignUpRequestDto req = new UserSignUpRequestDto("testuser", "password", "test@email.com", "nickname", true, UserRole.CUSTOMER, null);
+		when(userRepository.existsByEmail(req.email())).thenReturn(false);
+		when(passwordEncoder.encode(req.password())).thenReturn("encoded");
+		when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+		// When
+		UserSignUpResponseDto res = authService.signUp(req);
+
+		// Then
+		assertThat(res).isNotNull();
+		verify(couponClient).issueFirstCoupon(any());
+	}
+
+	@DisplayName("회원가입 실패 - 마스터키 불일치")
+	@Test
+	void signUp_masterKey_invalid() {
+		// Given
+		UserSignUpRequestDto req = new UserSignUpRequestDto("admin", "pass", "admin@email.com", "nickname", true, UserRole.MASTER, "wrong-key");
+		when(userRepository.existsByEmail(any())).thenReturn(false);
+
+		// When & Then
+		assertThatThrownBy(() -> authService.signUp(req))
+			.isInstanceOf(CustomException.class)
+			.hasMessage(UserExceptionCode.INVALID_MASTER_KEY.getMessage());
+	}
+
+	@DisplayName("로그인 성공")
+	@Test
+	void signIn_success() {
+		// Given
+		User raw = User.of("testuser", "encoded", "email@test.com", "nickname", true, UserRole.CUSTOMER, false);
+		User user = spy(raw);
+		doReturn(true).when(user).isApproved();
+		when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(user));
+		when(passwordEncoder.matches("password", "encoded")).thenReturn(true);
+		when(jwtUtil.createAccessToken(any(), any(), any())).thenReturn("access-token");
+		when(jwtUtil.createRefreshToken(any())).thenReturn("refresh-token");
+
+		UserSignInRequestDto req = new UserSignInRequestDto("testuser", "password");
+
+		// When
+		UserSignInResponseDto res = authService.signIn(req);
+
+		// Then
+		assertThat(res.accessToken()).isEqualTo("access-token");
+		assertThat(res.refreshToken()).isEqualTo("refresh-token");
+		verify(redisUtil).setDataExpire(startsWith("RT:"), eq("refresh-token"), anyLong());
+	}
+
+	@DisplayName("토큰 재발급 성공")
+	@Test
+	void reissueToken_success() {
+		// Given
+		UUID userId = UUID.randomUUID();
+		Claims claims = mock(Claims.class);
+		when(claims.get("userId", String.class)).thenReturn(userId.toString());
+		when(jwtUtil.parseClaims("refresh-token")).thenReturn(claims);
+		when(redisUtil.getData("RT:" + userId)).thenReturn("refresh-token");
+
+		User user = User.of("testuser", "pw", "email", "nickname", true, UserRole.CUSTOMER, false);
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+		when(jwtUtil.createAccessToken(any(), any(), any())).thenReturn("new-access");
+		when(jwtUtil.createRefreshToken(any())).thenReturn("new-refresh");
+
+		// When
+		TokenReissueResponseDto res = authService.reissueToken("refresh-token");
+
+		// Then
+		assertThat(res.accessToken()).isEqualTo("new-access");
+		assertThat(res.refreshToken()).isEqualTo("new-refresh");
+	}
+
+	@DisplayName("로그아웃 성공")
+	@Test
+	void logout_success() {
+		// Given
+		UUID userId = UUID.randomUUID();
+
+		// When
+		authService.logout(userId);
+
+		// Then
+		verify(redisUtil).deleteData("RT:" + userId);
+	}
+
+	@DisplayName("임시 비밀번호 전송 성공")
+	@Test
+	void resetPasswordAndSendTempPassword_success() {
+		// Given
+		User user = User.of("user", "pw", "email", "nickname", true, UserRole.CUSTOMER, false);
+		when(userRepository.findByUsernameAndEmail("user", "email")).thenReturn(Optional.of(user));
+		when(passwordEncoder.encode(any())).thenReturn("encoded");
+
+		// When
+		authService.resetPasswordAndSendTempPassword("user", "email");
+
+		// Then
+		verify(userRepository).findByUsernameAndEmail("user", "email");
+		verify(mailService).sendTemporaryPassword(eq("email"), any());
+	}
+}

--- a/client/user/src/test/java/com/live_commerce/user/application/service/UserServiceTest.java
+++ b/client/user/src/test/java/com/live_commerce/user/application/service/UserServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -87,6 +88,35 @@ class UserServiceTest {
 		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.FORBIDDEN);
 	}
 
+	@Test
+	@DisplayName("조회 실패 - 존재하지 않는 유저")
+	void getUser_notFound() {
+		// given
+		RequestUserDetails self = createUserDetails(userId, "ROLE_CUSTOMER");
+		when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+		// expect
+		CustomException ex = catchThrowableOfType(() -> userService.getUser(userId, self), CustomException.class);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.USER_NOT_FOUND);
+	}
+
+
+	@Test
+	@DisplayName("검색 실패 - 마스터가 아닌 유저")
+	void searchUser_forbidden() {
+		// given
+		RequestUserDetails normal = createUserDetails(UUID.randomUUID(), "ROLE_CUSTOMER");
+
+		// expect
+		CustomException ex = catchThrowableOfType(
+			() -> userService.searchUser(null, PageRequest.of(0, 10), normal),
+			CustomException.class
+		);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.FORBIDDEN);
+	}
+
 
 	@Test
 	@DisplayName("유저 정보 수정 성공")
@@ -139,6 +169,38 @@ class UserServiceTest {
 
 		// then
 		assertThat(user.isDeletedStatus()).isTrue();
+	}
+
+	@DisplayName("삭제 성공 - 일반 유저가 본인 계정 삭제")
+	@Test
+	void deleteUser_self_success() {
+		// Given
+		User user = createUser();
+		RequestUserDetails self = createUserDetails(userId, "ROLE_CUSTOMER");
+
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+		// When
+		userService.deleteUser(userId, self);
+
+		// Then
+		assertThat(user.isDeletedStatus()).isTrue();
+	}
+
+	@Test
+	@DisplayName("삭제 실패 - 일반 유저가 타인 삭제 시도")
+	void deleteUser_others_forbidden() {
+		// Given
+		User user = createUser();
+		RequestUserDetails other = createUserDetails(UUID.randomUUID(), "ROLE_CUSTOMER");
+
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+		// When & Then
+		CustomException ex = catchThrowableOfType(
+			() -> userService.deleteUser(userId, other), CustomException.class);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.FORBIDDEN);
 	}
 
 

--- a/client/user/src/test/java/com/live_commerce/user/application/service/UserServiceTest.java
+++ b/client/user/src/test/java/com/live_commerce/user/application/service/UserServiceTest.java
@@ -101,7 +101,6 @@ class UserServiceTest {
 		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.USER_NOT_FOUND);
 	}
 
-
 	@Test
 	@DisplayName("검색 실패 - 마스터가 아닌 유저")
 	void searchUser_forbidden() {
@@ -116,7 +115,6 @@ class UserServiceTest {
 
 		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.FORBIDDEN);
 	}
-
 
 	@Test
 	@DisplayName("유저 정보 수정 성공")
@@ -136,6 +134,80 @@ class UserServiceTest {
 		// then
 		assertThat(res.email()).isEqualTo("new@mail.com");
 		assertThat(res.nickname()).isEqualTo("newnick");
+	}
+
+	@Test
+	@DisplayName("마스터가 삭제된 유저 정보 수정 성공")
+	void updateUser_master_canUpdateDeletedUser() {
+		// given
+		User deletedUser = createUser();
+		deletedUser.markAsDeleted("admin");
+		RequestUserDetails master = createUserDetails(UUID.randomUUID(), "ROLE_MASTER");
+
+		UserUpdateRequestDto dto = new UserUpdateRequestDto("pw", "new@email.com", "newNick", true, null);
+
+		when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
+		when(passwordEncoder.encode("pw")).thenReturn("encoded");
+
+		// when
+		UserUpdateResponseDto result = userService.updateUser(userId, dto, master);
+
+		// then
+		assertThat(result.email()).isEqualTo("new@email.com");
+		assertThat(result.nickname()).isEqualTo("newNick");
+	}
+
+	@Test
+	@DisplayName("마스터가 삭제된 유저 조회 성공")
+	void getUser_master_canViewDeletedUser() {
+		// given
+		User deletedUser = createUser();
+		deletedUser.markAsDeleted("admin");
+		RequestUserDetails master = createUserDetails(UUID.randomUUID(), "ROLE_MASTER");
+
+		when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
+
+		// when
+		UserGetResponseDto result = userService.getUser(userId, master);
+
+		// then
+		assertThat(result.getUsername()).isEqualTo("user");
+	}
+
+	@Test
+	@DisplayName("일반 유저가 삭제된 유저 조회 시 예외")
+	void getUser_deletedUser_forbidden() {
+		// given
+		User deletedUser = createUser();
+		deletedUser.markAsDeleted("admin");
+		RequestUserDetails self = createUserDetails(userId, "ROLE_CUSTOMER");
+
+		when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
+
+		// expect
+		CustomException ex = catchThrowableOfType(() ->
+			userService.getUser(userId, self), CustomException.class);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.DELETED_USER);
+	}
+
+	@Test
+	@DisplayName("수정 실패 - 삭제된 유저")
+	void updateUser_deletedUser() {
+		// given
+		User user = createUser();
+		user.markAsDeleted("test");
+		UserUpdateRequestDto dto =
+			new UserUpdateRequestDto("pw", "email", "nick", true, null);
+		RequestUserDetails self = createUserDetails(userId, "ROLE_CUSTOMER");
+
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+		// expect
+		CustomException ex = catchThrowableOfType(() ->
+			userService.updateUser(userId, dto, self), CustomException.class);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.DELETED_USER);
 	}
 
 	@Test

--- a/client/user/src/test/java/com/live_commerce/user/application/service/UserServiceTest.java
+++ b/client/user/src/test/java/com/live_commerce/user/application/service/UserServiceTest.java
@@ -1,0 +1,153 @@
+package com.live_commerce.user.application.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.live_commerce.user.application.dto.auth.request.UserUpdateRequestDto;
+import com.live_commerce.user.application.dto.auth.response.UserUpdateResponseDto;
+import com.live_commerce.user.application.dto.user.response.UserGetResponseDto;
+import com.live_commerce.user.application.exception.CustomException;
+import com.live_commerce.user.application.exception.UserExceptionCode;
+import com.live_commerce.user.domain.model.User;
+import com.live_commerce.user.domain.model.UserRole;
+import com.live_commerce.user.domain.repository.UserRepository;
+import com.live_commerce.user.infrastructure.client.CouponClient;
+import com.live_commerce.user.infrastructure.common.JwtUtil;
+import com.live_commerce.user.infrastructure.common.RedisUtil;
+import com.live_commerce.user.infrastructure.security.RequestUserDetails;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class UserServiceTest {
+
+	@MockitoBean private UserRepository userRepository;
+	@MockitoBean private PasswordEncoder passwordEncoder;
+
+	@MockitoBean private JwtUtil jwtUtil;
+	@MockitoBean private RedisUtil redisUtil;
+	@MockitoBean private MailService mailService;
+	@MockitoBean private CouponClient couponClient;
+
+	@Autowired private UserService userService;
+
+	private final UUID userId = UUID.randomUUID();
+
+
+	@Test
+	@DisplayName("자기 자신 조회 성공")
+	void getUser_self_success() {
+		// given
+		User user = createUser();
+		RequestUserDetails self = createUserDetails(userId, "ROLE_CUSTOMER");
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+		// when
+		UserGetResponseDto result = userService.getUser(userId, self);
+
+		// then
+		assertThat(result.getUsername()).isEqualTo("user");
+	}
+
+	@Test
+	@DisplayName("마스터가 타인 조회 성공")
+	void getUser_master_success() {
+		// given
+		User user = createUser();
+		RequestUserDetails master = createUserDetails(UUID.randomUUID(), "ROLE_MASTER");
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+		// when - then
+		assertThat(userService.getUser(userId, master).getEmail()).isEqualTo("email@test.com");
+	}
+
+	@Test
+	@DisplayName("권한 없는 유저가 타인 조회 → FORBIDDEN")
+	void getUser_forbidden() {
+		// given
+		RequestUserDetails other = createUserDetails(UUID.randomUUID(), "ROLE_CUSTOMER");
+
+		// expect
+		CustomException ex = catchThrowableOfType(
+			() -> userService.getUser(userId, other), CustomException.class);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.FORBIDDEN);
+	}
+
+
+	@Test
+	@DisplayName("유저 정보 수정 성공")
+	void updateUser_success() {
+		// given
+		User user = createUser();
+		RequestUserDetails self = createUserDetails(userId, "ROLE_CUSTOMER");
+		UserUpdateRequestDto dto =
+			new UserUpdateRequestDto("newPw", "new@mail.com", "newnick", true, null);
+
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+		when(passwordEncoder.encode("newPw")).thenReturn("encodedPw");
+
+		// when
+		UserUpdateResponseDto res = userService.updateUser(userId, dto, self);
+
+		// then
+		assertThat(res.email()).isEqualTo("new@mail.com");
+		assertThat(res.nickname()).isEqualTo("newnick");
+	}
+
+	@Test
+	@DisplayName("마스터 아닌 유저가 권한 변경 → ROLE_CHANGE_FORBIDDEN")
+	void updateUser_roleChangeForbidden() {
+		// given
+		RequestUserDetails normal = createUserDetails(userId, "ROLE_CUSTOMER");
+		User user = createUser();
+		UserUpdateRequestDto dto =
+			new UserUpdateRequestDto(null, null, null, null, UserRole.MASTER);
+
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+		// expect
+		CustomException ex = catchThrowableOfType(
+			() -> userService.updateUser(userId, dto, normal), CustomException.class);
+
+		assertThat(ex.getExceptionCode()).isEqualTo(UserExceptionCode.ROLE_CHANGE_FORBIDDEN);
+	}
+
+	@Test
+	@DisplayName("마스터가 유저 삭제 성공")
+	void deleteUser_success() {
+		// given
+		User user = createUser();
+		RequestUserDetails master = createUserDetails(UUID.randomUUID(), "ROLE_MASTER");
+		when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+		// when
+		userService.deleteUser(userId, master);
+
+		// then
+		assertThat(user.isDeletedStatus()).isTrue();
+	}
+
+
+	private User createUser() {
+		return User.of("user", "pw", "email@test.com",
+			"nickname", true, UserRole.CUSTOMER, false);
+	}
+
+	private RequestUserDetails createUserDetails(UUID id, String role) {
+		return new RequestUserDetails(id, "user", List.of(() -> role));
+	}
+}

--- a/client/user/src/test/resources/application-test.yml
+++ b/client/user/src/test/resources/application-test.yml
@@ -1,0 +1,51 @@
+spring:
+
+  cloud:
+    config:
+      enabled: false                # config server 비활성화
+
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+        use_sql_comments: true
+
+  sql:
+    init:
+      mode: never  # schema.sql 사용 안 함
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+eureka:
+  client:
+    enabled: false
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql: trace
+
+
+gateway:
+  base-url: localhost:9999
+
+service:
+  jwt:
+    access-expiration: 3600000
+    refresh-expiration: 604800000
+
+user:
+  master-key: test-master-key
+
+


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 유저 도메인 테스트 및 삭제 유저 처리 로직 개선

* **세부 내용**
  * `UserService`, `AuthService` 테스트 코드 작성
    - 유저 조회/수정/삭제에 대한 정상/예외 케이스 테스트 추가
    - 탈퇴(삭제)된 유저에 대한 예외 처리 테스트 추가
  * 마스터 권한일 경우, 삭제된 유저도 조회/수정 가능하도록 서비스 로직 분기 처리
    - `findUserById`, `findUserEvenIfDeleted` 메서드 분리
    - `hasMasterRole` 조건에 따라 분기 처리
  * 일반 유저는 삭제된 유저 접근 시 `DELETED_USER` 예외 발생
  * 테스트 환경 구성: `application-test.yml`, H2 DB 설정

## 💡 추가 설명

* 코드 리뷰 시 특별히 참고해야 할 부분이 있다면 언급해주세요.
* 궁금한 점이나 논의하고 싶은 내용이 있다면 작성해주세요.

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
