### PR TITLE
feat: 게이트웨이 및 각 서비스의 Swagger 문서 설정 적용 (KAN-68)

### DIFF
--- a/client/ai/src/main/java/com/live_commerce/ai/infrastructure/config/SwaggerConfig.java
+++ b/client/ai/src/main/java/com/live_commerce/ai/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.live_commerce.ai.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+
+	@Value("${gateway.base-url}")
+	private String gatewayUrl;
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.servers(List.of(
+				new Server().url(gatewayUrl).description("Gateway Port")
+			))
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")
+				)
+			)
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.info(new Info()
+				.title("Live Commerce - AI Service API")
+				.description("AI 서비스 관련 API 명세서입니다.")
+				.version("v1.0"));
+	}
+}

--- a/client/ai/src/main/java/com/live_commerce/ai/infrastructure/filter/AuthenticationFilter.java
+++ b/client/ai/src/main/java/com/live_commerce/ai/infrastructure/filter/AuthenticationFilter.java
@@ -27,12 +27,13 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 		throws ServletException, IOException {
 
 		String requestUri = request.getRequestURI();
+		String method = request.getMethod();
 
 		// 인증이 필요 없는 경로는 필터를 통과시킴
 		if ((requestUri.startsWith("/api/v1/auth/") && !requestUri.equals("/api/v1/auth/logout")) ||
 			requestUri.startsWith("/swagger-ui/") ||
 			requestUri.startsWith("/v3/api-docs") ||
-			requestUri.startsWith("/api/v1/ai") ||
+			(requestUri.equals("/api/v1/ai") && method.equals("POST")) ||
 			requestUri.startsWith("/actuator")) {
 			filterChain.doFilter(request, response);
 			return;

--- a/client/ai/src/main/resources/application-prod.yml
+++ b/client/ai/src/main/resources/application-prod.yml
@@ -52,3 +52,7 @@ management:
   zipkin:
     tracing:
       endpoint: http://zipkin:9411/api/v2/spans
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/ai

--- a/client/chat/src/main/java/com/live_commerce/chat/infrastructure/config/SwaggerConfig.java
+++ b/client/chat/src/main/java/com/live_commerce/chat/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.live_commerce.chat.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+
+	@Value("${gateway.base-url}")
+	private String gatewayUrl;
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.servers(List.of(
+				new Server().url(gatewayUrl).description("Gateway Port")
+			))
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")
+				)
+			)
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.info(new Info()
+				.title("Live Commerce - Chat Service API")
+				.description("Chat 서비스 관련 API 명세서입니다.")
+				.version("v1.0"));
+	}
+}

--- a/client/chat/src/main/resources/application-prod.yml
+++ b/client/chat/src/main/resources/application-prod.yml
@@ -46,3 +46,6 @@ management:
     tracing:
       endpoint: http://zipkin:9411/api/v2/spans
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs/chat

--- a/client/company/src/main/java/com/live_commerce/company/infrastructure/config/SwaggerConfig.java
+++ b/client/company/src/main/java/com/live_commerce/company/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.live_commerce.company.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+
+	@Value("${gateway.base-url}")
+	private String gatewayUrl;
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.servers(List.of(
+				new Server().url(gatewayUrl).description("Gateway Port")
+			))
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")
+				)
+			)
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.info(new Info()
+				.title("Live Commerce - Company Service API")
+				.description("Company 서비스 관련 API 명세서입니다.")
+				.version("v1.0"));
+	}
+}

--- a/client/company/src/main/resources/application-prod.yml
+++ b/client/company/src/main/resources/application-prod.yml
@@ -43,3 +43,6 @@ management:
     pathmatch:
       matching-strategy: ant_path_matcher
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs/company

--- a/client/coupon/src/main/java/com/live_commerce/coupon/infrastructure/config/SwaggerConfig.java
+++ b/client/coupon/src/main/java/com/live_commerce/coupon/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.live_commerce.coupon.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+
+	@Value("${gateway.base-url}")
+	private String gatewayUrl;
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.servers(List.of(
+				new Server().url(gatewayUrl).description("Gateway Port")
+			))
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")
+				)
+			)
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.info(new Info()
+				.title("Live Commerce - Coupon Service API")
+				.description("Coupon 서비스 관련 API 명세서입니다.")
+				.version("v1.0"));
+	}
+}

--- a/client/coupon/src/main/resources/application-prod.yml
+++ b/client/coupon/src/main/resources/application-prod.yml
@@ -41,3 +41,7 @@ management:
 
 gateway:
   base-url: http://gateway:19091
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/coupon

--- a/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/config/SwaggerConfig.java
+++ b/client/livebroadcast/src/main/java/com/live_commerce/livebroadcast/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.live_commerce.livebroadcast.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+
+	@Value("${gateway.base-url}")
+	private String gatewayUrl;
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.servers(List.of(
+				new Server().url(gatewayUrl).description("Gateway Port")
+			))
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")
+				)
+			)
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.info(new Info()
+				.title("Live Commerce - Livebroadcast Service API")
+				.description("Livebroadcast 서비스 관련 API 명세서입니다.")
+				.version("v1.0"));
+	}
+}

--- a/client/livebroadcast/src/main/resources/application-prod.yml
+++ b/client/livebroadcast/src/main/resources/application-prod.yml
@@ -42,4 +42,7 @@ spring:
 gateway:
   base-url: http://gateway:19091
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs/livebroadcast
 

--- a/client/notification/src/main/java/com/live_commerce/notification/infrastructure/config/SwaggerConfig.java
+++ b/client/notification/src/main/java/com/live_commerce/notification/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.live_commerce.notification.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+
+	@Value("${gateway.base-url}")
+	private String gatewayUrl;
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.servers(List.of(
+				new Server().url(gatewayUrl).description("Gateway Port")
+			))
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")
+				)
+			)
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.info(new Info()
+				.title("Live Commerce - Notification Service API")
+				.description("Notification 서비스 관련 API 명세서입니다.")
+				.version("v1.0"));
+	}
+}

--- a/client/notification/src/main/resources/application-prod.yml
+++ b/client/notification/src/main/resources/application-prod.yml
@@ -50,3 +50,7 @@ management:
 
 gateway:
   base-url: http://gateway:19091
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/notification

--- a/client/order/src/main/java/com/live_commerce/order/infrastructure/config/SwaggerConfig.java
+++ b/client/order/src/main/java/com/live_commerce/order/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.live_commerce.order.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+
+	@Value("${gateway.base-url}")
+	private String gatewayUrl;
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.servers(List.of(
+				new Server().url(gatewayUrl).description("Gateway Port")
+			))
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")
+				)
+			)
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.info(new Info()
+				.title("Live Commerce - Order Service API")
+				.description("Order 서비스 관련 API 명세서입니다.")
+				.version("v1.0"));
+	}
+}

--- a/client/order/src/main/resources/application-prod.yml
+++ b/client/order/src/main/resources/application-prod.yml
@@ -50,3 +50,7 @@ management:
 
 gateway:
   base-url: http://gateway:19091
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/order

--- a/client/payment/src/main/java/com/live_commerce/payment/infrastructure/config/SwaggerConfig.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.live_commerce.payment.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+
+	@Value("${gateway.base-url}")
+	private String gatewayUrl;
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.servers(List.of(
+				new Server().url(gatewayUrl).description("Gateway Port")
+			))
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")
+				)
+			)
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.info(new Info()
+				.title("Live Commerce - Payment Service API")
+				.description("Payment 서비스 관련 API 명세서입니다.")
+				.version("v1.0"));
+	}
+}

--- a/client/payment/src/main/resources/application-prod.yml
+++ b/client/payment/src/main/resources/application-prod.yml
@@ -72,3 +72,7 @@ management:
   zipkin:
     tracing:
       endpoint: http://zipkin:9411/api/v2/spans
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/payment

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/config/SwaggerConfig.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.live_commerce.product.product.infrastructure.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+
+	@Value("${gateway.base-url}")
+	private String gatewayUrl;
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.servers(List.of(
+				new Server().url(gatewayUrl).description("Gateway Port")
+			))
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")
+				)
+			)
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.info(new Info()
+				.title("Live Commerce - Product Service API")
+				.description("Product 서비스 관련 API 명세서입니다.")
+				.version("v1.0"));
+	}
+}

--- a/client/product/src/main/resources/application-prod.yml
+++ b/client/product/src/main/resources/application-prod.yml
@@ -41,3 +41,7 @@ spring:
   redis:
     host: redis
     port: 6379
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/product

--- a/client/user/src/main/java/com/live_commerce/user/infrastructure/config/SwaggerConfig.java
+++ b/client/user/src/main/java/com/live_commerce/user/infrastructure/config/SwaggerConfig.java
@@ -1,0 +1,45 @@
+package com.live_commerce.user.infrastructure.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+@OpenAPIDefinition
+public class SwaggerConfig {
+
+	@Value("${gateway.base-url}")
+	private String gatewayUrl;
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.servers(List.of(
+				new Server().url(gatewayUrl).description("Gateway Port")
+			))
+			.components(new Components()
+				.addSecuritySchemes("bearerAuth", new SecurityScheme()
+					.type(SecurityScheme.Type.HTTP)
+					.scheme("bearer")
+					.bearerFormat("JWT")
+					.in(SecurityScheme.In.HEADER)
+					.name("Authorization")
+				)
+			)
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.info(new Info()
+				.title("Live Commerce - User Service API")
+				.description("유저 서비스 관련 API 명세서입니다.")
+				.version("v1.0"));
+	}
+}

--- a/client/user/src/main/resources/application-prod.yml
+++ b/client/user/src/main/resources/application-prod.yml
@@ -66,3 +66,7 @@ user:
 
 gateway:
   base-url: http://gateway:19091
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/user

--- a/server/config/src/main/resources/config-repo/ai-dev.yml
+++ b/server/config/src/main/resources/config-repo/ai-dev.yml
@@ -40,3 +40,7 @@ slack:
 
 gateway:
   base-url: http://localhost:19091
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/ai

--- a/server/config/src/main/resources/config-repo/chat-dev.yml
+++ b/server/config/src/main/resources/config-repo/chat-dev.yml
@@ -34,3 +34,6 @@ internal:
 gateway:
   base-url: http://localhost:19091
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs/chat

--- a/server/config/src/main/resources/config-repo/company-dev.yml
+++ b/server/config/src/main/resources/config-repo/company-dev.yml
@@ -40,3 +40,7 @@ management:
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/company

--- a/server/config/src/main/resources/config-repo/coupon-dev.yml
+++ b/server/config/src/main/resources/config-repo/coupon-dev.yml
@@ -27,3 +27,7 @@ spring:
 
 gateway:
   base-url: http://localhost:19091
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/coupon

--- a/server/config/src/main/resources/config-repo/gateway-dev.yml
+++ b/server/config/src/main/resources/config-repo/gateway-dev.yml
@@ -24,55 +24,55 @@ spring:
           - PreserveHostHeader=true # 헤더 유지
           - AddRequestHeader=Authorization, {Authorization}
       routes:
-        - id: ai
-          uri: lb://ai
+        - id: user
+          uri: lb://user
           predicates:
-            - Path=/api/v1/ai/**, /api-docs-ai
-
-        - id: chat
-          uri: lb://chat
-          predicates:
-            - Path=/api/v1/chattings/**, /api-docs-chat
+            - Path=/api/v1/users/**, /api/v1/auth/**, /v3/api-docs/user
 
         - id: company
           uri: lb://company
           predicates:
-            - Path=/api/v1/companies/**, /api-docs-company
+            - Path=/api/v1/companies/**, /v3/api-docs/company
 
         - id: coupon
           uri: lb://coupon
           predicates:
-            - Path=/api/v1/coupon-policies/**, /api/v1/issued-coupons/**, /api-docs-coupon
+            - Path=/api/v1/coupon-policies/**, /api/v1/issued-coupons/**, /v3/api-docs/coupon
 
         - id: livebroadcast
           uri: lb://livebroadcast
           predicates:
-            - Path=/api/v1/livebroadcasts/**, /api-docs-live-broadcast
+            - Path=/api/v1/livebroadcasts/**, /v3/api-docs/livebroadcast
 
         - id: notification
           uri: lb://notification
           predicates:
-            - Path=/api/v1/notifications/**, /api-docs-notification
+            - Path=/api/v1/notifications/**, /v3/api-docs/notification
 
         - id: order
           uri: lb://order
           predicates:
-            - Path=/api/v1/orders/**, /api-docs-order
+            - Path=/api/v1/orders/**, /v3/api-docs/order
 
         - id: payment
           uri: lb://payment
           predicates:
-            - Path=/api/v1/payments/**, /api-docs-payment
+            - Path=/api/v1/payments/**, /v3/api-docs/payment
 
         - id: product
           uri: lb://product
           predicates:
-            - Path=/api/v1/products/**, /api/v1/inventories/**, /api-docs-product
+            - Path=/api/v1/products/**, /api/v1/inventories/**, /v3/api-docs/product
 
-        - id: user
-          uri: lb://user
+        - id: chat
+          uri: lb://chat
           predicates:
-            - Path=/api/v1/users/**, /api/v1/auth/**, /v3/api-docs/user, /api-docs-user
+            - Path=/api/v1/chattings/**, /v3/api-docs/chat
+
+        - id: ai
+          uri: lb://ai
+          predicates:
+            - Path=/api/v1/ai/**, /v3/api-docs/ai
 
 
 
@@ -94,50 +94,33 @@ service:
   jwt:
     secret-key: ${JWT_SECRET_KEY}
 
-#  service:
-#    whitelist:
-#      paths:
-#        - "/auth/**"
-#        - "/users/**"
-#        - "/api-docs-user"
-#        - "/api-docs-hub"
-#        - "/api-docs-company"
-#        - "/api-docs-product"
-#        - "/api-docs-order"
-#        - "/api-docs-delivery"
-#        - "/api-docs-coupon"
-#        - "/api-docs-payment"
-#        - "/api-docs-chat"
-#        - "/api-docs-ai"
-#        - "/api-docs-notification"
-#        - "/api-docs-live-broadcast"
-#        - "/swagger-ui/**"
-#        - "/swagger-ui.html"
-#        - "/v3/api-docs/**"
-#        - "/swagger-resources/**"
-#        - "/webjars/**"
+  whitelist:
+    paths:
+      - "/swagger-ui/**"
+      - "/swagger-ui.html"
+      - "/v3/api-docs/**"
 
-#springdoc:
-#  swagger-ui:
-#    path: /swagger-ui
-#    urls:
-#      - name: user
-#        url: /v3/api-docs/user
-#      - name: company
-#        url: /api-docs-company
-#      - name: coupon
-#        url: /api-docs-coupon
-#      - name: live-broadcast
-#        url: /api-docs-live-broadcast
-#      - name: notification
-#        url: /api-docs-notification
-#      - name: order
-#        url: /api-docs-order
-#      - name: payment
-#        url: /api-docs-payment
-#      - name: product
-#        url: /api-docs-product
-#      - name: chat
-#        url: /api-docs-chat
-#      - name: ai
-#        url: /api-docs-ai
+springdoc:
+  swagger-ui:
+    path: /swagger-ui
+    urls:
+      - name: user
+        url: /v3/api-docs/user
+      - name: company
+        url: /v3/api-docs/company
+      - name: coupon
+        url: /v3/api-docs/coupon
+      - name: livebroadcast
+        url: /v3/api-docs/livebroadcast
+      - name: notification
+        url: /v3/api-docs/notification
+      - name: order
+        url: /v3/api-docs/order
+      - name: payment
+        url: /v3/api-docs/payment
+      - name: product
+        url: /v3/api-docs/product
+      - name: chat
+        url: /v3/api-docs/chat
+      - name: ai
+        url: /v3/api-docs/ai

--- a/server/config/src/main/resources/config-repo/livebroadcast-dev.yml
+++ b/server/config/src/main/resources/config-repo/livebroadcast-dev.yml
@@ -39,3 +39,7 @@ spring:
 
 gateway:
   base-url: http://localhost:19091
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/livebroadcast

--- a/server/config/src/main/resources/config-repo/notification-dev.yml
+++ b/server/config/src/main/resources/config-repo/notification-dev.yml
@@ -41,3 +41,7 @@ management:
 
 gateway:
   base-url: http://localhost:19091
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/notification

--- a/server/config/src/main/resources/config-repo/order-dev.yml
+++ b/server/config/src/main/resources/config-repo/order-dev.yml
@@ -42,3 +42,7 @@ management:
 
 gateway:
   base-url: http://localhost:19091
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/order

--- a/server/config/src/main/resources/config-repo/payment-dev.yml
+++ b/server/config/src/main/resources/config-repo/payment-dev.yml
@@ -65,3 +65,7 @@ management:
     export:
       prometheus:
         enabled: true
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/payment

--- a/server/config/src/main/resources/config-repo/product-dev.yml
+++ b/server/config/src/main/resources/config-repo/product-dev.yml
@@ -39,3 +39,7 @@ spring:
 
 gateway:
   base-url: http://localhost:19091
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs/product

--- a/server/config/src/main/resources/config-repo/user-dev.yml
+++ b/server/config/src/main/resources/config-repo/user-dev.yml
@@ -65,4 +65,6 @@ management:
 gateway:
   base-url: http://localhost:19091
 
-
+springdoc:
+  api-docs:
+    path: /v3/api-docs/user

--- a/server/gateway/src/main/java/com/live_commerce/gateway/filter/AuthenticationFilter.java
+++ b/server/gateway/src/main/java/com/live_commerce/gateway/filter/AuthenticationFilter.java
@@ -19,8 +19,9 @@ public class AuthenticationFilter implements GlobalFilter {
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 		String path = exchange.getRequest().getURI().getPath();
+		String method = exchange.getRequest().getMethod().name();
 
-		if (isPublicPath(path)) {
+		if (isPublicPath(path, method)) {
 			return chain.filter(exchange);
 		}
 
@@ -35,29 +36,27 @@ public class AuthenticationFilter implements GlobalFilter {
 		String userId = claims.get("userId", String.class);
 		String username = claims.get("username", String.class);
 		String role = claims.get("role", String.class);
+		String finalRole = role.startsWith("ROLE_") ? role : "ROLE_" + role;
 
 		ServerWebExchange modifiedExchange = exchange.mutate()
 			.request(exchange.getRequest().mutate()
 				.header("X-User-Id", userId)
 				.header("X-User-Username", username)
-				.header("X-User-Role", role)
+				.header("X-User-Role", finalRole)
 				.build())
 			.build();
 
 		return chain.filter(modifiedExchange);
 	}
 
-	private boolean isPublicPath(String path) {
-		return !path.equals("/api/v1/auth/logout") &&
-			!path.startsWith("/api/v1/auth/approve") && (
-			path.startsWith("/api/v1/ai") ||
-				path.startsWith("/api/v1/auth/") ||
-				(path.startsWith("/api/v1/issued-coupons/") && path.endsWith("/signup-first")) ||
-				path.startsWith("/swagger-ui/") ||
-				path.startsWith("/v3/api-docs/") ||
-				path.startsWith("/actuator")
-		);
+	private boolean isPublicPath(String path, String method) {
+		return (path.equals("/api/v1/ai") && method.equalsIgnoreCase("POST")) ||
+			path.startsWith("/api/v1/auth/") ||
+			path.startsWith("/swagger-ui/") ||
+			path.startsWith("/v3/api-docs") ||
+			path.startsWith("/actuator");
 	}
+
 
 }
 

--- a/server/gateway/src/main/resources/application-prod.yml
+++ b/server/gateway/src/main/resources/application-prod.yml
@@ -22,43 +22,43 @@ spring:
         - id: ai
           uri: lb://ai
           predicates:
-            - Path=/api/v1/ai/**, /api-docs-ai
+            - Path=/api/v1/ai/**, /v3/api-docs/ai
         - id: chat
           uri: lb://chat
           predicates:
-            - Path=/api/v1/chattings/**, /api-docs-chat
+            - Path=/api/v1/chattings/**, /v3/api-docs/chat
         - id: company
           uri: lb://company
           predicates:
-            - Path=/api/v1/companies/**, /api-docs-company
+            - Path=/api/v1/companies/**, /v3/api-docs/company
         - id: coupon
           uri: lb://coupon
           predicates:
-            - Path=/api/v1/coupon-policies/**, /api/v1/issued-coupons/**, /api-docs-coupon
+            - Path=/api/v1/coupon-policies/**, /api/v1/issued-coupons/**, /v3/api-docs/coupon
         - id: livebroadcast
           uri: lb://livebroadcast
           predicates:
-            - Path=/api/v1/livebroadcasts/**, /ws/viewers/**, /api-docs-live-broadcast
+            - Path=/api/v1/livebroadcasts/**, /ws/viewers/**, /v3/api-docs/livebroadcast
         - id: notification
           uri: lb://notification
           predicates:
-            - Path=/api/v1/notifications/**, /api-docs-notification
+            - Path=/api/v1/notifications/**, /v3/api-docs/notification
         - id: order
           uri: lb://order
           predicates:
-            - Path=/api/v1/orders/**, /api-docs-order
+            - Path=/api/v1/orders/**, /v3/api-docs/order
         - id: payment
           uri: lb://payment
           predicates:
-            - Path=/api/v1/payments/**, /api-docs-payment
+            - Path=/api/v1/payments/**, /v3/api-docs/payment
         - id: product
           uri: lb://product
           predicates:
-            - Path=/api/v1/products/**, /api/v1/inventories/**, /api-docs-product
+            - Path=/api/v1/products/**, /api/v1/inventories/**, /v3/api-docs/product
         - id: user
           uri: lb://user
           predicates:
-            - Path=/api/v1/users/**, /api/v1/auth/**, /v3/api-docs/user, /api-docs-user
+            - Path=/api/v1/users/**, /api/v1/auth/**, /v3/api-docs/user
 
 
 eureka:
@@ -69,6 +69,37 @@ eureka:
 service:
   jwt:
     secret-key: ${JWT_SECRET_KEY}
+
+  whitelist:
+    paths:
+      - "/swagger-ui/**"
+      - "/swagger-ui.html"
+      - "/v3/api-docs/**"
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui
+    urls:
+      - name: user
+        url: /v3/api-docs/user
+      - name: company
+        url: /v3/api-docs/company
+      - name: coupon
+        url: /v3/api-docs/coupon
+      - name: livebroadcast
+        url: /v3/api-docs/livebroadcast
+      - name: notification
+        url: /v3/api-docs/notification
+      - name: order
+        url: /v3/api-docs/order
+      - name: payment
+        url: /v3/api-docs/payment
+      - name: product
+        url: /v3/api-docs/product
+      - name: chat
+        url: /v3/api-docs/chat
+      - name: ai
+        url: /v3/api-docs/ai
 
 management:
   endpoints:


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [x] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 게이트웨이 및 각 서비스의 Swagger 문서 설정 적용

* **세부 내용**
  * application-dev.yml, application-prod.yml에 /v3/api-docs/** 경로 라우팅 및 whitelist 설정 추가
  * 각 서비스별 SwaggerConfig 클래스 추가 (@OpenAPIDefinition, Gateway 기반 주소, JWT 설정 포함)
  * 각 서비스별 SwaggerConfig에 gateway.base-url 주입 방식으로 Server 설정
  * JWT 토큰을 사용하는 서비스에는 Swagger에서 "Authorize" 버튼을 통해 토큰 입력 후 요청 가능
  * 모든 서비스 Swagger UI 정상 동작 확인 완료

## 💡 추가 설명

* 코드 리뷰 시 특별히 참고해야 할 부분이 있다면 언급해주세요.
* 궁금한 점이나 논의하고 싶은 내용이 있다면 작성해주세요.

## 📚 참고 자료 (선택 사항)
![image](https://github.com/user-attachments/assets/77a4b32d-2a78-4892-84a1-24043ff0d00c)
