### PR TITLE
feat: Kafka 기반 재고 차감 이벤트 처리 로직 추가 (KAN-78)

### DIFF
--- a/client/product/build.gradle
+++ b/client/product/build.gradle
@@ -66,6 +66,10 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-config'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryConsumer.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryConsumer.java
@@ -1,0 +1,38 @@
+package com.live_commerce.product.inventory.application.service;
+
+import com.live_commerce.product.inventory.domain.exception.InventoryException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class InventoryConsumer {
+
+    private final InventoryService inventoryService;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @KafkaListener(topics = "order.created", groupId = "inventory-group", containerFactory = "kafkaListenerContainerFactory")
+    public void consumeOrderCreated(OrderCreatedEvent event) {
+        log.info("order.created 이벤트 수신: {}", event);
+
+        try {
+            inventoryService.decreaseInventory(event.productId(), event.quantity());
+
+            InventoryDecreasedEvent decreasedEvent = new InventoryDecreasedEvent(
+                    event.orderId(),
+                    event.productId(),
+                    event.quantity()
+            );
+            kafkaTemplate.send("inventory.decreased", decreasedEvent);
+            log.info("inventory.decreased 이벤트 발행 완료: {}", decreasedEvent);
+        } catch (InventoryException e) {
+            log.error("재고 차감 실패: {}", e.getMessage());
+            // 실패 이벤트 추가 (보상 트랜잭션)
+        }
+    }
+
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryConsumer.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryConsumer.java
@@ -15,7 +15,7 @@ public class InventoryConsumer {
     private final InventoryService inventoryService;
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    @KafkaListener(topics = "order.created", groupId = "inventory-group", containerFactory = "kafkaListenerContainerFactory")
+    @KafkaListener(topics = "order-created", groupId = "inventory-group", containerFactory = "kafkaListenerContainerFactory")
     public void consumeOrderCreated(OrderCreatedEvent event) {
         log.info("order.created 이벤트 수신: {}", event);
 
@@ -27,8 +27,8 @@ public class InventoryConsumer {
                     event.productId(),
                     event.quantity()
             );
-            kafkaTemplate.send("inventory.decreased", decreasedEvent);
-            log.info("inventory.decreased 이벤트 발행 완료: {}", decreasedEvent);
+            kafkaTemplate.send("inventory-decreased", decreasedEvent);
+            log.info("inventory-decreased 이벤트 발행 완료: {}", decreasedEvent);
         } catch (InventoryException e) {
             log.error("재고 차감 실패: {}", e.getMessage());
             // 실패 이벤트 추가 (보상 트랜잭션)

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryDecreasedEvent.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryDecreasedEvent.java
@@ -1,0 +1,10 @@
+package com.live_commerce.product.inventory.application.service;
+
+import java.util.UUID;
+
+public record InventoryDecreasedEvent(
+        UUID orderId, // 추적용
+        UUID productId,
+        int decreasedQuantity // 실제 차감 개수
+) {
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/application/service/OrderCreatedEvent.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/application/service/OrderCreatedEvent.java
@@ -1,0 +1,10 @@
+package com.live_commerce.product.inventory.application.service;
+
+import java.util.UUID;
+
+public record OrderCreatedEvent(
+        UUID orderId,
+        UUID productId,
+        int quantity
+) {
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/config/KafkaConsumerConfig.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,56 @@
+package com.live_commerce.product.inventory.infrastructure.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+
+    // Kafka 컨슈머 팩토리를 생성하는 빈을 정의합니다.
+    // ConsumerFactory는 Kafka 컨슈머 인스턴스를 생성하는 데 사용됩니다.
+    // 각 컨슈머는 이 팩토리를 통해 생성된 설정을 기반으로 작동합니다.
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        JsonDeserializer<Object> jsonDeserializer = new JsonDeserializer<>();
+        jsonDeserializer.addTrustedPackages("*");
+
+        // 컨슈머 팩토리 설정을 위한 맵을 생성합니다.
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, "inventory-group");
+
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        configProps.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        configProps.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(configProps, new StringDeserializer(), jsonDeserializer);
+    }
+
+    // Kafka 리스너 컨테이너 팩토리를 생성하는 빈을 정의합니다.
+    // ConcurrentKafkaListenerContainerFactory는 Kafka 메시지를 비동기적으로 수신하는 리스너 컨테이너를 생성하는 데 사용됩니다.
+    // 이 팩토리는 @KafkaListener 어노테이션이 붙은 메서드들을 실행할 컨테이너를 제공합니다.
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        // ConcurrentKafkaListenerContainerFactory를 생성합니다.
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        // 컨슈머 팩토리를 리스너 컨테이너 팩토리에 설정합니다.
+        factory.setConsumerFactory(consumerFactory());
+        // 설정된 리스너 컨테이너 팩토리를 반환합니다.
+        return factory;
+    }
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/config/KafkaProducerConfig.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/infrastructure/config/KafkaProducerConfig.java
@@ -1,0 +1,31 @@
+package com.live_commerce.product.inventory.infrastructure.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/client/product/src/main/java/com/live_commerce/product/inventory/presentation/controller/InventoryTestProducerController.java
+++ b/client/product/src/main/java/com/live_commerce/product/inventory/presentation/controller/InventoryTestProducerController.java
@@ -1,0 +1,32 @@
+package com.live_commerce.product.inventory.presentation.controller;
+
+
+import com.live_commerce.product.inventory.application.service.OrderCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/inventories/test")
+public class InventoryTestProducerController {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @PostMapping("/order-created")
+    public String sendOrderCreatedEvent(
+            @RequestParam int quantity
+    ) {
+        UUID orderId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID productId = UUID.fromString("30000000-0000-0000-0000-000000000001");
+        OrderCreatedEvent event = new OrderCreatedEvent(orderId, productId, quantity);
+        kafkaTemplate.send("order.created", event);
+
+        return "order.created 이벤트 발행 완료";
+    }
+}

--- a/server/config/src/main/resources/config-repo/livebroadcast-dev.yml
+++ b/server/config/src/main/resources/config-repo/livebroadcast-dev.yml
@@ -32,6 +32,16 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: inventory-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: '*'
+
 #  sql:
 #    init:
 #      mode: always
@@ -39,6 +49,8 @@ spring:
 
 gateway:
   base-url: http://localhost:19091
+
+
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 재고 도메인에 Kafka 기반 이벤트 수신 로직을 추가했습니다.
  * `order-created` 이벤트를 수신하여 재고를 차감하는 구조를 구현했습니다. (order-created 이벤트는 테스트용으로 임시로 만들어 둠)
  *  테스트를 위한 임시 테스트 컨트롤러를 추가하여 수동으로 이벤트 발행 및 재고 차감 테스트를 진행했습니다.
 
* **세부 내용**
  * Kafka `order-created` 이벤트 수신 후, productId/quantity를 기반으로 재고를 차감합니다.
  * 차감 성공 시 `inventory-decreased` 이벤트를 발행합니다.
  * 실패 케이스에 대한 보상 트랜잭션 로직은 별도로 추가 예정입니다.

## 💡 추가 설명
![image](https://github.com/user-attachments/assets/6317f16f-0663-494c-8f81-998e98e301c8)


## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
