### PR TITLE
refactor: PaymentController v1/v2 분리 (KAN-83)

### DIFF
--- a/client/payment/src/main/java/com/live_commerce/payment/infrastructure/kafka/config/KafkaConsumerConfig.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/infrastructure/kafka/config/KafkaConsumerConfig.java
@@ -16,7 +16,7 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 @Configuration
 public class KafkaConsumerConfig {
 
-	public static final String GROUP_ID = "payment-service-group";
+	public static final String GROUP_ID = "payment-group";
 
 	@Bean
 	public ConsumerFactory<String, String> paymentConsumerFactory() {

--- a/client/payment/src/main/java/com/live_commerce/payment/presentation/controller/PaymentControllerV2.java
+++ b/client/payment/src/main/java/com/live_commerce/payment/presentation/controller/PaymentControllerV2.java
@@ -22,7 +22,7 @@ import com.live_commerce.payment.application.dto.request.PaymentSearchCondition;
 import com.live_commerce.payment.application.dto.response.PaymentApproveResponseDto;
 import com.live_commerce.payment.application.dto.response.PaymentGetResponseDto;
 import com.live_commerce.payment.application.dto.response.PaymentReadyResponseDto;
-import com.live_commerce.payment.application.service.PaymentService;
+import com.live_commerce.payment.application.service.PaymentServiceV2;
 import com.live_commerce.payment.infrastructure.common.ResponseUtil;
 import com.live_commerce.payment.infrastructure.security.RequestUserDetails;
 import com.live_commerce.payment.presentation.common.ApiResponse;
@@ -30,18 +30,18 @@ import com.live_commerce.payment.presentation.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/payments")
+@RequestMapping("/api/v2/payments")
 @RequiredArgsConstructor
-public class PaymentController {
+public class PaymentControllerV2 {
 
-	private final PaymentService paymentService;
+	private final PaymentServiceV2 paymentServiceV2;
 
 	@PostMapping("/ready")
 	public ResponseEntity<ApiResponse<PaymentReadyResponseDto>> readyPayment(
 		@AuthenticationPrincipal RequestUserDetails requestUserDetails,
 		@RequestBody PaymentReadyRequestDto requestDto
 	) {
-		PaymentReadyResponseDto response = paymentService.readyPayment(requestUserDetails, requestDto);
+		PaymentReadyResponseDto response = paymentServiceV2.readyPayment(requestUserDetails, requestDto);
 		return ResponseUtil.success(response);
 	}
 
@@ -50,7 +50,7 @@ public class PaymentController {
 		@AuthenticationPrincipal RequestUserDetails userDetails,
 		@RequestBody PaymentApproveRequestDto requestDto
 	) {
-		PaymentApproveResponseDto response = paymentService.approvePayment(
+		PaymentApproveResponseDto response = paymentServiceV2.approvePayment(
 			requestDto,
 			userDetails.getUserId()
 		);
@@ -62,7 +62,7 @@ public class PaymentController {
 		@PathVariable UUID paymentId,
 		@AuthenticationPrincipal RequestUserDetails userDetails
 	) {
-		PaymentGetResponseDto response = paymentService.getPayment(paymentId, userDetails);
+		PaymentGetResponseDto response = paymentServiceV2.getPayment(paymentId, userDetails);
 		return ResponseUtil.success(response);
 	}
 
@@ -72,7 +72,7 @@ public class PaymentController {
 		@AuthenticationPrincipal RequestUserDetails userDetails,
 		@PageableDefault(size = 10) Pageable pageable
 	) {
-		Page<PaymentGetResponseDto> result = paymentService.getPayments(condition, userDetails, pageable);
+		Page<PaymentGetResponseDto> result = paymentServiceV2.getPayments(condition, userDetails, pageable);
 		return ResponseUtil.success(result);
 	}
 
@@ -81,7 +81,7 @@ public class PaymentController {
 		@PathVariable UUID orderId,
 		@AuthenticationPrincipal RequestUserDetails userDetails
 	) {
-		PaymentRefundResponseDto response = paymentService.refundPaymentByOrderId(orderId, userDetails);
+		PaymentRefundResponseDto response = paymentServiceV2.refundPaymentByOrderId(orderId, userDetails);
 		return ResponseUtil.success(response);
 	}
 
@@ -90,7 +90,7 @@ public class PaymentController {
 		@PathVariable UUID orderId,
 		@AuthenticationPrincipal RequestUserDetails userDetails
 	) {
-		paymentService.cancelPaymentByOrderId(orderId, userDetails);
+		paymentServiceV2.cancelPaymentByOrderId(orderId, userDetails);
 		return ResponseUtil.noContent();
 	}
 

--- a/server/config/src/main/resources/config-repo/gateway-dev.yml
+++ b/server/config/src/main/resources/config-repo/gateway-dev.yml
@@ -57,7 +57,7 @@ spring:
         - id: payment
           uri: lb://payment
           predicates:
-            - Path=/api/v1/payments/**, /v3/api-docs/payment
+            - Path=/api/v1/payments/**, /api/v2/payments/**, /v3/api-docs/payment
 
         - id: product
           uri: lb://product

--- a/server/gateway/src/main/resources/application-prod.yml
+++ b/server/gateway/src/main/resources/application-prod.yml
@@ -50,7 +50,7 @@ spring:
         - id: payment
           uri: lb://payment
           predicates:
-            - Path=/api/v1/payments/**, /v3/api-docs/payment
+            - Path=/api/v1/payments/**, /api/v2/payments/**, /v3/api-docs/payment
         - id: product
           uri: lb://product
           predicates:


### PR DESCRIPTION
## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트
* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * PaymentController를 v1, v2 버전으로 명확히 분리

* **세부 내용**
  * 기존 `/api/v1/payments`에 대응하는 PaymentController는 `PaymentService`를 사용하도록 수정
  * 새로운 `/api/v2/payments` 경로에 대해 `PaymentControllerV2`와 `PaymentServiceV2` 연동
  * gateway 설정에 `/api/v2/payments/**` 추가

## 💡 추가 설명

* 코드 리뷰 시 특별히 참고해야 할 부분이 있다면 언급해주세요.
* 궁금한 점이나 논의하고 싶은 내용이 있다면 작성해주세요.

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
