### PR TITLE
feat: 유저 회원가입 완료 시 Kafka를 통한 첫 가입 쿠폰 이벤트 발행 로직 구현(KAN-84)

### DIFF
--- a/client/user/build.gradle
+++ b/client/user/build.gradle
@@ -80,6 +80,9 @@ dependencies {
 	// H2 DB
 	testRuntimeOnly 'com.h2database:h2'
 
+	// kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+
 }
 
 dependencyManagement {

--- a/client/user/src/main/java/com/live_commerce/user/application/service/AuthServiceV2.java
+++ b/client/user/src/main/java/com/live_commerce/user/application/service/AuthServiceV2.java
@@ -1,0 +1,197 @@
+package com.live_commerce.user.application.service;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.live_commerce.user.application.dto.auth.request.UserSignInRequestDto;
+import com.live_commerce.user.application.dto.auth.request.UserSignUpRequestDto;
+import com.live_commerce.user.application.dto.auth.response.UserSignInResponseDto;
+import com.live_commerce.user.application.dto.auth.response.UserSignUpResponseDto;
+import com.live_commerce.user.application.dto.auth.response.TokenReissueResponseDto;
+import com.live_commerce.user.application.exception.CustomException;
+import com.live_commerce.user.application.exception.UserExceptionCode;
+import com.live_commerce.user.domain.model.User;
+import com.live_commerce.user.domain.model.UserRole;
+import com.live_commerce.user.domain.repository.UserRepository;
+import com.live_commerce.user.infrastructure.common.JwtUtil;
+import com.live_commerce.user.infrastructure.common.PasswordGenerator;
+import com.live_commerce.user.infrastructure.common.RedisUtil;
+import com.live_commerce.user.infrastructure.kafka.dto.FirstJoinCouponMessage;
+import com.live_commerce.user.infrastructure.kafka.producer.UserSignupEventProducer;
+
+import io.jsonwebtoken.Claims;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceV2 {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtUtil jwtUtil;
+	private final RedisUtil redisUtil;
+	private final MailService mailService;
+	private final UserSignupEventProducer userSignupEventProducer;
+
+	private static final String REFRESH_KEY_PREFIX = "RT:";
+
+	@Value("${service.jwt.refresh-expiration}")
+	private long refreshTokenExpirationMillis;
+
+	@Value("${user.master-key}")
+	private String masterKey;
+
+	@Transactional
+	public UserSignUpResponseDto signUp(UserSignUpRequestDto request) {
+		validateEmail(request.email());
+
+		// MASTER 권한 등록 키 검증
+		if (request.userRole() == UserRole.MASTER) {
+			validateMasterRegistrationKey(request.masterKey());
+		}
+
+		boolean approved = switch (request.userRole()) {
+			case SELLER, SHOW_HOST -> false;
+			default -> true;
+		};
+
+		String encodedPassword = passwordEncoder.encode(request.password());
+		User user = request.toEntity(encodedPassword, approved);
+		User savedUser = userRepository.save(user);
+
+		// Kafka로 첫가입 쿠폰 발급 이벤트 발행
+		userSignupEventProducer.sendFirstJoinCouponEvent(new FirstJoinCouponMessage(savedUser.getUserId()));
+
+		return UserSignUpResponseDto.from(savedUser);
+	}
+
+	@Transactional
+	public UserSignInResponseDto signIn(UserSignInRequestDto requestDto) {
+		User user = userRepository.findByUsername(requestDto.username())
+			.filter(u -> passwordEncoder.matches(requestDto.password(), u.getPassword()))
+			.map(this::validateActiveUser)
+			.orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_CREDENTIALS));
+
+		if (!user.isApproved()) {
+			throw new CustomException(UserExceptionCode.UNAPPROVED_USER);
+		}
+
+		UUID userId = user.getUserId();
+		String accessToken = jwtUtil.createAccessToken(userId, user.getUsername(), user.getUserRole());
+		String refreshToken = jwtUtil.createRefreshToken(userId);
+
+		String redisKey = REFRESH_KEY_PREFIX + userId;
+		redisUtil.setDataExpire(redisKey, refreshToken, refreshTokenExpirationMillis);
+
+		return UserSignInResponseDto.from(accessToken, refreshToken);
+	}
+
+	@Transactional
+	public TokenReissueResponseDto reissueToken(String refreshToken) {
+		jwtUtil.validateToken(refreshToken);
+		Claims token = jwtUtil.parseClaims(refreshToken);
+
+		UUID userId = UUID.fromString(token.get("userId", String.class));
+		String redisKey = REFRESH_KEY_PREFIX + userId;
+		String storedRefreshToken = redisUtil.getData(redisKey);
+
+		if (storedRefreshToken == null || !storedRefreshToken.equals(refreshToken)) {
+			throw new CustomException(UserExceptionCode.INVALID_REFRESH_TOKEN);
+		}
+
+		User user = userRepository.findById(userId)
+			.map(this::validateActiveUser)
+			.orElseThrow(() -> new CustomException(UserExceptionCode.USER_NOT_FOUND));
+
+		String newAccessToken = jwtUtil.createAccessToken(userId, user.getUsername(), user.getUserRole());
+		String newRefreshToken = jwtUtil.createRefreshToken(userId);
+
+		redisUtil.setDataExpire(redisKey, newRefreshToken, refreshTokenExpirationMillis);
+		return new TokenReissueResponseDto(newAccessToken, newRefreshToken);
+	}
+
+	@Transactional
+	public void logout(UUID userId) {
+		String redisKey = REFRESH_KEY_PREFIX + userId;
+		redisUtil.deleteData(redisKey);
+	}
+
+	@Transactional
+	public void sendFindUsernameCode(String email) {
+		findActiveUserByEmail(email);
+		mailService.sendVerificationCode(email);
+	}
+
+	@Transactional
+	public String confirmFindUsernameCode(String email, String inputCode) {
+		String storedCode = redisUtil.getData(email);
+
+		if (storedCode == null) {
+			throw new CustomException(UserExceptionCode.VERIFICATION_CODE_EXPIRED);
+		}
+
+		if (!storedCode.equals(inputCode)) {
+			throw new CustomException(UserExceptionCode.INVALID_VERIFICATION_CODE);
+		}
+
+		User user = findActiveUserByEmail(email);
+		redisUtil.deleteData(email);
+		return user.getUsername();
+	}
+
+	@Transactional
+	public void resetPasswordAndSendTempPassword(String username, String email) {
+		User user = findActiveUserByUsernameAndEmail(username, email);
+		String tempPassword = PasswordGenerator.generateTempPassword(10);
+		String encoded = passwordEncoder.encode(tempPassword);
+		user.changePassword(encoded);
+		mailService.sendTemporaryPassword(email, tempPassword);
+	}
+
+	@Transactional
+	public void approveUser(UUID userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CustomException(UserExceptionCode.USER_NOT_FOUND));
+
+		user.approve();
+	}
+
+	private User findActiveUserByEmail(String email) {
+		return userRepository.findByEmail(email)
+			.map(this::validateActiveUser)
+			.orElseThrow(() -> new CustomException(UserExceptionCode.USER_NOT_FOUND));
+	}
+
+	private User findActiveUserByUsernameAndEmail(String username, String email) {
+		return userRepository.findByUsernameAndEmail(username, email)
+			.map(this::validateActiveUser)
+			.orElseThrow(() -> new CustomException(UserExceptionCode.USER_NOT_FOUND));
+	}
+
+	private User validateActiveUser(User user) {
+		if (user.isDeletedStatus()) {
+			throw new CustomException(UserExceptionCode.DELETED_USER);
+		}
+		return user;
+	}
+
+	private void validateEmail(String email) {
+		validateDuplicate(userRepository.existsByEmail(email), UserExceptionCode.DUPLICATE_EMAIL);
+	}
+
+	private void validateDuplicate(boolean exists, UserExceptionCode exceptionCode) {
+		if (exists) {
+			throw new CustomException(exceptionCode);
+		}
+	}
+
+	private void validateMasterRegistrationKey(String inputKey) {
+		if (!inputKey.equals(masterKey)) {
+			throw new CustomException(UserExceptionCode.INVALID_MASTER_KEY);
+		}
+	}
+}

--- a/client/user/src/main/java/com/live_commerce/user/infrastructure/config/SecurityConfig.java
+++ b/client/user/src/main/java/com/live_commerce/user/infrastructure/config/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 상태를 사용하지 않음
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers(
-					"/api/v1/auth/**", // 인증되지 않은 경로
+					"/api/v1/auth/**",
+					"/api/v2/auth/**",
 					"/swagger-ui/**",
 					"/v3/api-docs/**",
 					"/actuator/**"

--- a/client/user/src/main/java/com/live_commerce/user/infrastructure/filter/AuthenticationFilter.java
+++ b/client/user/src/main/java/com/live_commerce/user/infrastructure/filter/AuthenticationFilter.java
@@ -29,15 +29,17 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 		String requestUri = request.getRequestURI();
 
 		// 인증이 필요 없는 경로는 필터를 통과시킴
-		if ((requestUri.startsWith("/api/v1/auth/") &&
-			!requestUri.startsWith("/api/v1/auth/approve") &&
-			!requestUri.equals("/api/v1/auth/logout")) ||
+		if ((requestUri.startsWith("/api/v1/auth/") ||
+			requestUri.startsWith("/api/v2/auth/") ||
 			requestUri.startsWith("/swagger-ui/") ||
 			requestUri.startsWith("/v3/api-docs") ||
-			requestUri.startsWith("/actuator")) {
+			requestUri.startsWith("/actuator")) &&
+			!requestUri.startsWith("/api/v1/auth/approve") &&
+			!requestUri.equals("/api/v1/auth/logout")) {
 			filterChain.doFilter(request, response);
 			return;
 		}
+
 
 		// 요청 헤더에서 사용자 정보 추출
 		String userIdHeader = request.getHeader("X-User-Id");

--- a/client/user/src/main/java/com/live_commerce/user/infrastructure/kafka/config/KafkaProducerConfig.java
+++ b/client/user/src/main/java/com/live_commerce/user/infrastructure/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,31 @@
+package com.live_commerce.user.infrastructure.kafka.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+	@Bean
+	public ProducerFactory<String, String> producerFactory() {
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+		configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+		return new DefaultKafkaProducerFactory<>(configProps);
+	}
+
+	@Bean
+	public KafkaTemplate<String, String> kafkaTemplate() {
+		return new KafkaTemplate<>(producerFactory());
+	}
+}

--- a/client/user/src/main/java/com/live_commerce/user/infrastructure/kafka/dto/FirstJoinCouponMessage.java
+++ b/client/user/src/main/java/com/live_commerce/user/infrastructure/kafka/dto/FirstJoinCouponMessage.java
@@ -1,0 +1,8 @@
+package com.live_commerce.user.infrastructure.kafka.dto;
+
+import java.util.UUID;
+
+public record FirstJoinCouponMessage(
+	UUID userId
+) {
+}

--- a/client/user/src/main/java/com/live_commerce/user/infrastructure/kafka/producer/UserSignupEventProducer.java
+++ b/client/user/src/main/java/com/live_commerce/user/infrastructure/kafka/producer/UserSignupEventProducer.java
@@ -1,0 +1,30 @@
+package com.live_commerce.user.infrastructure.kafka.producer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.live_commerce.user.infrastructure.kafka.dto.FirstJoinCouponMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserSignupEventProducer {
+
+	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	private static final String FIRST_COUPON_TOPIC = "first-coupon-topic";
+
+	public void sendFirstJoinCouponEvent(FirstJoinCouponMessage event) {
+		try {
+			String json = objectMapper.writeValueAsString(event);
+			kafkaTemplate.send(FIRST_COUPON_TOPIC, event.userId().toString(), json);
+			log.info("[Kafka] 회원가입 쿠폰 이벤트 전송 완료: {}", json);
+		} catch (JsonProcessingException e) {
+			log.error("[Kafka] 직렬화 실패: {}", e.getMessage(), e);
+		}
+	}
+}

--- a/client/user/src/main/java/com/live_commerce/user/presentation/controller/AuthControllerV2.java
+++ b/client/user/src/main/java/com/live_commerce/user/presentation/controller/AuthControllerV2.java
@@ -1,0 +1,92 @@
+package com.live_commerce.user.presentation.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.live_commerce.user.application.dto.auth.request.*;
+import com.live_commerce.user.application.dto.auth.response.*;
+import com.live_commerce.user.application.service.AuthServiceV2;
+import com.live_commerce.user.infrastructure.common.ResponseUtil;
+import com.live_commerce.user.infrastructure.security.RequestUserDetails;
+import com.live_commerce.user.presentation.common.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v2/auth")
+@RequiredArgsConstructor
+public class AuthControllerV2 {
+
+	private final AuthServiceV2 authServiceV2;
+
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponse<UserSignUpResponseDto>> signUp(
+		@RequestBody @Valid UserSignUpRequestDto requestDto
+	) {
+		UserSignUpResponseDto response = authServiceV2.signUp(requestDto);
+		return ResponseUtil.success(response);
+	}
+
+	@PostMapping("/signin")
+	public ResponseEntity<ApiResponse<UserSignInResponseDto>> signIn(
+		@RequestBody UserSignInRequestDto requestDto
+	) {
+		UserSignInResponseDto response = authServiceV2.signIn(requestDto);
+		return ResponseUtil.success(response);
+	}
+
+	@PostMapping("/code")
+	public ResponseEntity<ApiResponse<String>> sendFindUsernameCode(
+		@RequestBody @Valid UserFindUsernameRequestDto request
+	) {
+		authServiceV2.sendFindUsernameCode(request.email());
+		return ResponseUtil.success("인증번호가 이메일로 전송되었습니다.");
+	}
+
+	@PostMapping("/verify")
+	public ResponseEntity<ApiResponse<String>> confirmFindUsernameCode(
+		@RequestBody @Valid UserFindUsernameVerifyRequestDto request
+	) {
+		String username = authServiceV2.confirmFindUsernameCode(request.email(), request.code());
+		return ResponseUtil.success(username);
+	}
+
+	@PostMapping("/reset-password")
+	public ResponseEntity<ApiResponse<String>> resetPasswordAndSendTempPassword(
+		@RequestBody @Valid UserResetPasswordRequestDto request
+	) {
+		authServiceV2.resetPasswordAndSendTempPassword(request.username(), request.email());
+		return ResponseUtil.success("임시 비밀번호가 이메일로 전송되었습니다.");
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse<String>> logout(
+		@AuthenticationPrincipal RequestUserDetails userDetails
+	) {
+		authServiceV2.logout(userDetails.getUserId());
+		return ResponseUtil.success("로그아웃 되었습니다.");
+	}
+
+	@PostMapping("/reissue")
+	public ResponseEntity<ApiResponse<TokenReissueResponseDto>> reissue(
+		@RequestBody @Valid TokenReissueRequestDto request
+	) {
+		TokenReissueResponseDto response = authServiceV2.reissueToken(request.refreshToken());
+		return ResponseUtil.success(response);
+	}
+
+	@PostMapping("/approve/{userId}")
+	@PreAuthorize("hasRole('MASTER')")
+	public ResponseEntity<ApiResponse<String>> approveUser(
+		@PathVariable UUID userId
+	) {
+		authServiceV2.approveUser(userId);
+		return ResponseUtil.success("사용자가 승인되었습니다.");
+	}
+}
+

--- a/server/config/src/main/resources/config-repo/gateway-dev.yml
+++ b/server/config/src/main/resources/config-repo/gateway-dev.yml
@@ -27,7 +27,7 @@ spring:
         - id: user
           uri: lb://user
           predicates:
-            - Path=/api/v1/users/**, /api/v1/auth/**, /v3/api-docs/user
+            - Path=/api/v1/users/**, /api/v1/auth/**, /api/v2/auth/**, /v3/api-docs/user
 
         - id: company
           uri: lb://company

--- a/server/gateway/src/main/java/com/live_commerce/gateway/filter/AuthenticationFilter.java
+++ b/server/gateway/src/main/java/com/live_commerce/gateway/filter/AuthenticationFilter.java
@@ -52,6 +52,7 @@ public class AuthenticationFilter implements GlobalFilter {
 	private boolean isPublicPath(String path, String method) {
 		return (path.equals("/api/v1/ai") && method.equalsIgnoreCase("POST")) ||
 			path.startsWith("/api/v1/auth/") ||
+			path.startsWith("/api/v2/auth/") ||
 			path.startsWith("/swagger-ui/") ||
 			path.startsWith("/v3/api-docs") ||
 			path.startsWith("/actuator");

--- a/server/gateway/src/main/resources/application-prod.yml
+++ b/server/gateway/src/main/resources/application-prod.yml
@@ -58,7 +58,7 @@ spring:
         - id: user
           uri: lb://user
           predicates:
-            - Path=/api/v1/users/**, /api/v1/auth/**, /v3/api-docs/user
+            - Path=/api/v1/users/**, /api/v1/auth/**, /api/v2/auth/**, /v3/api-docs/user
 
 
 eureka:


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 유저 회원가입 완료 시 Kafka를 통한 첫 가입 쿠폰 이벤트 발행 로직 구현

* **세부 내용**
  * AuthServiceV2 신규 생성 (회원가입 로직 Feign 제거 → Kafka 이벤트 발행 방식으로 변경)
  * 회원가입 완료 후 first-coupon-topic으로 FirstJoinCouponMessage 이벤트 발행
  * Kafka 관련 Producer 설정(KafkaProducerConfig) 추가
  * UserSignupEventProducer 생성 및 ObjectMapper 직렬화 후 Kafka 전송
  * 인증 관련 SecurityConfig, AuthenticationFilter 수정 (/api/v2/auth/** 경로 허용 처리)
  * 회원가입용 컨트롤러 AuthControllerV2 추가

## 💡 추가 설명

* 회원가입 시 Kafka 이벤트를 통해 Coupon 서비스로 첫가입 쿠폰 발급이 정상 처리되는 것까지 테스트 완료했습니다.

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
