### PR TITLE
feat: 방송 중 상품 할인 기능 및 Redis 캐싱 구현

### DIFF
--- a/client/product/src/main/java/com/live_commerce/product/product/application/dto/LiveDiscountRequestDto.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/application/dto/LiveDiscountRequestDto.java
@@ -1,0 +1,13 @@
+package com.live_commerce.product.product.application.dto;
+
+import java.time.Duration;
+
+public record LiveDiscountRequestDto (
+        Integer discountPrice,
+        Integer durationMinutes
+) {
+
+    public Duration toDuration() {
+        return Duration.ofMinutes(durationMinutes);
+    }
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/application/dto/ProductPriceResponseDto.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/application/dto/ProductPriceResponseDto.java
@@ -1,0 +1,10 @@
+package com.live_commerce.product.product.application.dto;
+
+import java.util.UUID;
+
+public record ProductPriceResponseDto(
+        UUID productId,
+        Integer currentPrice,
+        boolean discounted
+) {
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/application/service/ProductDiscountCacheService.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/application/service/ProductDiscountCacheService.java
@@ -1,0 +1,30 @@
+package com.live_commerce.product.product.application.service;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProductDiscountCacheService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String KEY_PREFIX = "discount:";
+
+    public void cacheDiscountPrice(UUID productId, Integer discountPrice, Duration duration){
+        String key = KEY_PREFIX + productId.toString();
+        redisTemplate.opsForValue().set(key, discountPrice.toString(), duration);
+    }
+
+    public Optional<Integer> getDiscountPrice(UUID productId){
+        String key = KEY_PREFIX + productId.toString();
+        String value = redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(value).map(Integer::valueOf);
+    }
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/application/service/ProductDiscountService.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/application/service/ProductDiscountService.java
@@ -1,0 +1,53 @@
+package com.live_commerce.product.product.application.service;
+
+import com.live_commerce.product.product.application.dto.LiveDiscountRequestDto;
+import com.live_commerce.product.product.application.validation.ProductValidator;
+import com.live_commerce.product.product.domain.model.Product;
+import com.live_commerce.product.product.domain.model.ProductDiscount;
+import com.live_commerce.product.product.domain.repository.ProductDiscountRepository;
+import com.live_commerce.product.product.domain.repository.ProductRepository;
+import com.live_commerce.product.product.infrastructure.security.RequestUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ProductDiscountService {
+
+    private final ProductRepository productRepository;
+    private final ProductDiscountRepository productDiscountRepository;
+    private final ProductDiscountCacheService productDiscountCacheService;
+    private final ProductValidator productValidator;
+
+
+    public void applyLiveDiscount(UUID productId, @Valid LiveDiscountRequestDto request, RequestUserDetails userDetails) {
+        Product product = productValidator.validateAndFindProduct(productId);
+
+        validateDiscountPrice(product.getPrice(), request.discountPrice());
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime endAt = now.plus(request.toDuration());
+
+        ProductDiscount discount = ProductDiscount.builder()
+                .product(product)
+                .discountPrice(request.discountPrice())
+                .startAt(now)
+                .endAt(endAt)
+                .appliedBy(userDetails.getUserId())
+                .build();
+
+        productDiscountRepository.save(discount);
+
+        productDiscountCacheService.cacheDiscountPrice(productId, request.discountPrice(), request.toDuration());
+    }
+
+    private void validateDiscountPrice(Integer originalPrice, Integer discountPrice) {
+        if (discountPrice >= originalPrice) {
+            throw new IllegalArgumentException("할인 가격은 원래 가격보다 낮아야 합니다.");
+        }
+    }
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/application/service/ProductService.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/application/service/ProductService.java
@@ -35,6 +35,7 @@ public class ProductService {
     private final ProductQueryRepository productQueryRepository;
     private final InventoryService inventoryService;
     private final PermissionValidator permissionValidator;
+    private final ProductDiscountCacheService productDiscountCacheService;
 
     private static final List<Integer> ALLOWED_PAGE_SIZES = List.of(10, 30, 50);
 
@@ -126,5 +127,16 @@ public class ProductService {
     @Transactional(readOnly = true)
     public Product findProductEntity(UUID productId) {
         return productValidator.validateAndFindProduct(productId);
+    }
+
+    @Transactional(readOnly = true)
+    public ProductPriceResponseDto getProductPrice(UUID productId) {
+        Product product = productValidator.validateAndFindProduct(productId);
+
+        Integer currentPrice = productDiscountCacheService.getDiscountPrice(productId).orElse(product.getPrice());
+
+        boolean isDiscounted = !currentPrice.equals(product.getPrice());
+
+        return new ProductPriceResponseDto(productId, currentPrice, isDiscounted);
     }
 }

--- a/client/product/src/main/java/com/live_commerce/product/product/domain/model/ProductDiscount.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/domain/model/ProductDiscount.java
@@ -1,0 +1,48 @@
+package com.live_commerce.product.product.domain.model;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_product_discount", schema = "products")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductDiscount {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    private Integer discountPrice;
+
+    private LocalDateTime startAt;
+
+    private LocalDateTime endAt;
+
+    private UUID appliedBy;
+
+    @Builder
+    public ProductDiscount(Product product, Integer discountPrice, LocalDateTime startAt, LocalDateTime endAt, UUID appliedBy){
+        this.product = product;
+        this.discountPrice = discountPrice;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.appliedBy = appliedBy;
+    }
+
+    public boolean isActiveNow() {
+        LocalDateTime now = LocalDateTime.now();
+        return (startAt.isBefore(now) && endAt.isAfter(now));
+    }
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/domain/repository/ProductDiscountRepository.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/domain/repository/ProductDiscountRepository.java
@@ -1,0 +1,7 @@
+package com.live_commerce.product.product.domain.repository;
+
+import com.live_commerce.product.product.domain.model.ProductDiscount;
+
+public interface ProductDiscountRepository {
+    <S extends ProductDiscount> S save(S productDiscount);
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/kafka/consumer/InventoryEventConsumer.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/kafka/consumer/InventoryEventConsumer.java
@@ -19,7 +19,7 @@ public class InventoryEventConsumer {
     private final InventoryService inventoryService;
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    @KafkaListener(topics = "inventory-decrease")
+    @KafkaListener(topics = "inventory-decrease", concurrency = "4", containerFactory = "kafkaListenerContainerFactory")
     public void consumeOrderCreated(OrderRequestedInventoryEvent event) {
         log.info("inventory-decrease 이벤트 수신: {}", event);
 
@@ -31,7 +31,7 @@ public class InventoryEventConsumer {
                     event.productId(),
                     event.quantity()
             );
-            kafkaTemplate.send("inventory-decreased", decreasedEvent);
+            kafkaTemplate.send("inventory-decreased", event.productId().toString(), decreasedEvent);
             log.info("inventory-decreased 이벤트 발행 완료: {}", decreasedEvent);
         } catch (InventoryException e) {
             log.error("재고 차감 실패: {}, 이유: {}", event.orderId(), e.getMessage());

--- a/client/product/src/main/java/com/live_commerce/product/product/infrastructure/repository/JpaProductDiscountRepository.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/infrastructure/repository/JpaProductDiscountRepository.java
@@ -1,0 +1,8 @@
+package com.live_commerce.product.product.infrastructure.repository;
+
+import com.live_commerce.product.product.domain.model.ProductDiscount;
+import com.live_commerce.product.product.domain.repository.ProductDiscountRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaProductDiscountRepository extends JpaRepository<ProductDiscount, Long>, ProductDiscountRepository {
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/presentation/controller/ProductController.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/presentation/controller/ProductController.java
@@ -1,11 +1,14 @@
 package com.live_commerce.product.product.presentation.controller;
 
+import com.live_commerce.product.product.application.service.ProductDiscountService;
 import com.live_commerce.product.product.application.service.ProductRankingService;
 import com.live_commerce.product.product.application.dto.*;
 import com.live_commerce.product.product.application.service.ProductService;
+import com.live_commerce.product.product.application.validation.ProductValidator;
 import com.live_commerce.product.product.infrastructure.common.ResponseUtil;
 import com.live_commerce.product.product.infrastructure.security.RequestUserDetails;
 import com.live_commerce.product.product.presentation.common.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +26,8 @@ public class ProductController {
 
     private final ProductService productService;
     private final ProductRankingService productRankingService;
+    private final ProductValidator productValidator;
+    private final ProductDiscountService productDiscountService;
 
     @PreAuthorize("hasAnyRole('MASTER','SELLER')")
     @PostMapping
@@ -85,4 +90,29 @@ public class ProductController {
         List<PopularProductsResponseDto> top10Products = productRankingService.getTop10PopularProducts();
         return ResponseUtil.success(top10Products);
     }
+
+    @PreAuthorize("hasAnyRole('MASTER', 'SHOW_HOST')")
+    @PostMapping("/{productId}/live-discount")
+    public ResponseEntity<ApiResponse<String>> applyLiveDiscount(
+            @PathVariable UUID productId,
+            @RequestBody @Valid LiveDiscountRequestDto request,
+            @AuthenticationPrincipal RequestUserDetails userDetails
+    ){
+        productValidator.validateProductExists(productId);
+
+        productDiscountService.applyLiveDiscount(
+                productId,
+                request,
+                userDetails
+        );
+
+        return ResponseUtil.success("할인이 적용되었습니다.");
+    }
+
+    @GetMapping("/{productId}/price")
+    public ResponseEntity<ApiResponse<ProductPriceResponseDto>> getProductPrice(@PathVariable UUID productId) {
+        ProductPriceResponseDto responseDto = productService.getProductPrice(productId);
+        return ResponseUtil.success(responseDto);
+    }
+
 }

--- a/server/config/src/main/resources/config-repo/product-dev.yml
+++ b/server/config/src/main/resources/config-repo/product-dev.yml
@@ -56,6 +56,7 @@ spring:
           inventory-decreased:com.live_commerce.product.product.infrastructure.kafka.event.InventoryDecreasedEvent,
           inventory-rollback:com.live_commerce.product.product.infrastructure.kafka.event.InventoryRollbackEvent
       listener:
+        concurrency: 4
         ack-mode: MANUAL_IMMEDIATE
 
 gateway:


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 방송 도중에 상품의 가격을 업데이트하는 기능

* **세부 내용**
  *  쇼호스트가 방송 도중 상품에 대해 일시적인 할인을 적용할 수 있는 기능 구현
  * `ProductDiscount` 엔티티 도입으로 할인 정보를 별도 도메인으로 관리
  * Redis를 활용한 할인 가격 TTL 캐싱 처리
  * 할인 기간이 지나면 Redis에서 자동 만료되도록 설정
  * 가격 조회 API에서 할인 중일 경우 할인 가격을 우선적으로 반환

## 💡 추가 설명
![image](https://github.com/user-attachments/assets/c9e839c4-3f89-44a0-a33d-28a8121d39a3)

방송 중 할인 적용 POST /api/v1/products/{productId}/live-discount

![image](https://github.com/user-attachments/assets/53b4d413-2632-407e-80e2-fc0e3df74656)
할인 적용된 상품 가격 조회 GET /api/v1/products/{productId}/price

![image](https://github.com/user-attachments/assets/7ad77aad-d2b2-4bf1-b84b-d9f9bf9c7faf)
TTL 만료 이후 가격 조회 결과



## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
