### PR TITLE
feat: 주문 도메인에 상품 가격 조회용 FeignClient 연동 및 실시간 가격 적용

### DIFF
--- a/client/order/src/main/java/com/live_commerce/order/infrastructure/client/feign/ProductClient.java
+++ b/client/order/src/main/java/com/live_commerce/order/infrastructure/client/feign/ProductClient.java
@@ -2,6 +2,7 @@ package com.live_commerce.order.infrastructure.client.feign;
 
 import com.live_commerce.order.infrastructure.client.request.InventoryDecreaseRequestDto;
 import com.live_commerce.order.infrastructure.client.request.InventoryIncreaseRequestDto;
+import com.live_commerce.order.infrastructure.client.request.ProductOrderPriceDto;
 import com.live_commerce.order.infrastructure.client.response.ProductCreateResponseDto;
 import com.live_commerce.order.infrastructure.client.response.InventoryCheckQuantityResponseDto;
 import com.live_commerce.order.infrastructure.client.response.InventoryCheckResponseDto;
@@ -40,4 +41,8 @@ public interface ProductClient {
             @RequestParam("productId") UUID productId,
             @RequestParam("orderQuantity") int orderQuantity
     );
+
+    // 실시간 상품 가격 조회(타임 세일)
+    @GetMapping("/api/v1/products/{productId}/price-for-order")
+    ApiResponse<ProductOrderPriceDto> getPriceForOrder(@PathVariable("productId") UUID productId);
 }

--- a/client/order/src/main/java/com/live_commerce/order/infrastructure/client/request/ProductOrderPriceDto.java
+++ b/client/order/src/main/java/com/live_commerce/order/infrastructure/client/request/ProductOrderPriceDto.java
@@ -1,0 +1,8 @@
+package com.live_commerce.order.infrastructure.client.request;
+
+import java.util.UUID;
+
+public record ProductOrderPriceDto (
+        UUID productId,
+        Integer currentPrice
+) {}

--- a/client/order/src/main/java/com/live_commerce/order/kafkaOrder/service/OrderCreateServiceKafka.java
+++ b/client/order/src/main/java/com/live_commerce/order/kafkaOrder/service/OrderCreateServiceKafka.java
@@ -11,6 +11,7 @@ import com.live_commerce.order.infrastructure.client.feign.BroadcastClient;
 import com.live_commerce.order.infrastructure.client.feign.CouponClient;
 import com.live_commerce.order.infrastructure.client.feign.ProductClient;
 import com.live_commerce.order.infrastructure.client.feignEnum.BroadcastStatus;
+import com.live_commerce.order.infrastructure.client.request.ProductOrderPriceDto;
 import com.live_commerce.order.infrastructure.client.response.*;
 import com.live_commerce.order.presentation.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -53,6 +54,11 @@ public class OrderCreateServiceKafka {
 
         log.info("상품 정보 들고오기" + productResponseByOrder);
 
+        // 1.2 실시간 상품 가격 조회
+        ApiResponse<ProductOrderPriceDto> requestProductPrice = productClient.getPriceForOrder(request.productId());
+        ProductOrderPriceDto productOrderPriceDto = requestProductPrice.getData();
+        int unitPrice = productOrderPriceDto.currentPrice();
+
         // productId에 해당하는 상품이 아예 없는 경우
         if (productResponseByOrder == null) {
             throw new OrderException("해당 상품이 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
@@ -73,7 +79,8 @@ public class OrderCreateServiceKafka {
         // 5. total 주문 금액 계산
         // 주문한 수량 * 주문한 상품 한 개의 가격
         log.info("상품의 가격 : " + productResponseByOrder.price());
-        double productTotalPrice = orderQty * productResponseByOrder.price();
+        //double productTotalPrice = orderQty * productResponseByOrder.price();
+        double productTotalPrice = orderQty * unitPrice;
         log.info("총 상품 주문 금액 계산 : " + productTotalPrice);
 
         ///////////////////////////////////////////////////////////////////////////////

--- a/client/product/src/main/java/com/live_commerce/product/product/application/dto/ProductOrderPriceDto.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/application/dto/ProductOrderPriceDto.java
@@ -1,0 +1,9 @@
+package com.live_commerce.product.product.application.dto;
+
+import java.util.UUID;
+
+public record ProductOrderPriceDto (
+        UUID productId,
+        Integer currentPrice
+) {
+}

--- a/client/product/src/main/java/com/live_commerce/product/product/application/service/ProductService.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/application/service/ProductService.java
@@ -139,4 +139,13 @@ public class ProductService {
 
         return new ProductPriceResponseDto(productId, currentPrice, isDiscounted);
     }
+
+    @Transactional(readOnly = true)
+    public ProductOrderPriceDto getCurrentPriceForOrder(UUID productId) {
+        Product product = productValidator.validateAndFindProduct(productId);
+
+        Integer currentPrice = productDiscountCacheService.getDiscountPrice(productId).orElse(product.getPrice());
+
+        return new ProductOrderPriceDto(productId, currentPrice);
+    }
 }

--- a/client/product/src/main/java/com/live_commerce/product/product/domain/model/ProductDiscount.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/domain/model/ProductDiscount.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @Table(name = "p_product_discount", schema = "products")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ProductDiscount {
+public class ProductDiscount extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/client/product/src/main/java/com/live_commerce/product/product/presentation/controller/ProductController.java
+++ b/client/product/src/main/java/com/live_commerce/product/product/presentation/controller/ProductController.java
@@ -109,10 +109,24 @@ public class ProductController {
         return ResponseUtil.success("할인이 적용되었습니다.");
     }
 
+    /**
+     * 사용자용 가격확인 api
+     */
     @GetMapping("/{productId}/price")
     public ResponseEntity<ApiResponse<ProductPriceResponseDto>> getProductPrice(@PathVariable UUID productId) {
         ProductPriceResponseDto responseDto = productService.getProductPrice(productId);
         return ResponseUtil.success(responseDto);
     }
+
+    /**
+     * 주문용 가격확인 api
+     */
+    @GetMapping("/{productId}/price-for-order")
+    public ResponseEntity<ApiResponse<ProductOrderPriceDto>> getPriceForOrder(@PathVariable UUID productId) {
+        ProductOrderPriceDto dto = productService.getCurrentPriceForOrder(productId);
+        return ResponseUtil.success(dto);
+    }
+
+
 
 }


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 주문 도메인에 상품 가격 조회용 FeignClient 연동 및 실시간 가격 적용

* **세부 내용**
  * 주문 생성 시 상품 도메인의 가격 조회 api 를 호출하여 실시간 가격(할인 포함)을 반영하도록 수정
  * 상품 도메인과의 도메인 경계를 유지하며, 할인 캐싱도 고려한 현재가격 반영. 할인 가격이 캐싱되어있지않으면 정가 반환

## 💡 추가 설명



## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
