### PR TITLE
feat: lua script 기반 재고차감 api 추가

### DIFF
--- a/livebroadcast/src/test/java/com/live_commerce/livebroadcast/BroadcastProductServiceTest.java
+++ b/livebroadcast/src/test/java/com/live_commerce/livebroadcast/BroadcastProductServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.List;
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.*;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class BroadcastProductServiceTest {
 
+    @Autowired
     @InjectMocks
     private BroadcastProductService broadcastProductService;
 

--- a/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryService.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryService.java
@@ -2,6 +2,7 @@ package com.live_commerce.product.inventory.application.service;
 
 
 import com.live_commerce.product.inventory.application.dto.request.InventoryCreateRequestDto;
+import com.live_commerce.product.inventory.application.dto.request.InventoryDecreaseRequestDto;
 import com.live_commerce.product.inventory.application.dto.response.InventoryCheckQuantityResponseDto;
 import com.live_commerce.product.inventory.application.dto.response.InventoryCheckOrderableResponseDto;
 import com.live_commerce.product.inventory.application.dto.response.InventoryResponseDto;
@@ -16,11 +17,14 @@ import com.live_commerce.product.product.domain.repository.ProductRepository;
 import com.live_commerce.product.inventory.infrastructure.redisson.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RScript;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.UUID;
 
 @Slf4j
@@ -33,6 +37,9 @@ public class InventoryService {
     private final InventoryValidator inventoryValidator;
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final StringRedisTemplate redisTemplate;
+    private final RedissonClient redissonClient;
+
+    private static final String STOCK_KEY_PREFIX = "inventory:stock:";
 
     @Transactional
     public InventoryResponseDto createInventory(InventoryCreateRequestDto requestDto) {
@@ -42,7 +49,60 @@ public class InventoryService {
 
         Inventory inventory = InventoryMapper.createDtoToEntity(requestDto);
         inventoryRepository.save(inventory);
+
+        // Redis 재고 초기화
+        redisTemplate.opsForValue().set(STOCK_KEY_PREFIX + inventory.getProductId(), String.valueOf(inventory.getAvailableQuantity()));
+
         return InventoryMapper.entityToDto(inventory);
+    }
+
+    @Transactional
+    public void decreaseInventoryWithLua(UUID productId, int quantity) {
+        String stockKey = STOCK_KEY_PREFIX + productId;
+
+        // Lua Script: 재고 확인 및 차감
+        // 리턴 값: 차감 후 재고 (>=0), -1: 키 없음, -2: 재고 부족
+        String luaScript =
+                "local stock = redis.call('get', KEYS[1]) " +
+                "if not stock then return -1 end " +
+                "if tonumber(stock) < tonumber(ARGV[1]) then return -2 end " +
+                "return redis.call('decrby', KEYS[1], ARGV[1])";
+
+        Long result = redissonClient.getScript()
+                .eval(RScript.Mode.READ_WRITE,
+                        luaScript,
+                        RScript.ReturnType.INTEGER,
+                        Collections.singletonList(stockKey),
+                        quantity);
+
+        if (result == -1) {
+            // Redis에 재고가 없으면 DB에서 로드 후 재시도 (또는 예외 처리)
+            Inventory inventory = inventoryRepository.findByProductIdAndDeletedStatusFalse(productId)
+                    .orElseThrow(InventoryException::forInventoryNotFound);
+            redisTemplate.opsForValue().set(stockKey, String.valueOf(inventory.getAvailableQuantity()));
+            
+            // 로드 후 다시 시도
+            result = redissonClient.getScript()
+                    .eval(RScript.Mode.READ_WRITE,
+                            luaScript,
+                            RScript.ReturnType.INTEGER,
+                            Collections.singletonList(stockKey),
+                            quantity);
+        }
+
+        if (result == -2) {
+            throw InventoryException.forInventoryOutOfStock();
+        }
+
+        if (result == -1) { // 로드 후에도 없으면
+             throw InventoryException.forInventoryNotFound();
+        }
+
+        // DB 재고 업데이트
+        int updated = inventoryRepository.decreaseInventoryAtomically(productId, quantity);
+        if (updated == 0) {
+            throw InventoryException.forInventoryOutOfStock();
+        }
     }
 
     @Transactional(readOnly = true)

--- a/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryService.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/application/service/InventoryService.java
@@ -12,19 +12,17 @@ import com.live_commerce.product.inventory.domain.exception.InventoryException;
 import com.live_commerce.product.inventory.domain.model.Inventory;
 import com.live_commerce.product.inventory.domain.model.InventoryStatus;
 import com.live_commerce.product.inventory.domain.repository.InventoryRepository;
+import com.live_commerce.product.inventory.infrastructure.redis.InventoryRedisService;
 import com.live_commerce.product.product.infrastructure.kafka.event.InventorySoldOutEvent;
 import com.live_commerce.product.product.domain.repository.ProductRepository;
 import com.live_commerce.product.inventory.infrastructure.redisson.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.redisson.api.RScript;
-import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.UUID;
 
 @Slf4j
@@ -37,9 +35,7 @@ public class InventoryService {
     private final InventoryValidator inventoryValidator;
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final StringRedisTemplate redisTemplate;
-    private final RedissonClient redissonClient;
-
-    private static final String STOCK_KEY_PREFIX = "inventory:stock:";
+    private final InventoryRedisService inventoryRedisService;
 
     @Transactional
     public InventoryResponseDto createInventory(InventoryCreateRequestDto requestDto) {
@@ -49,60 +45,7 @@ public class InventoryService {
 
         Inventory inventory = InventoryMapper.createDtoToEntity(requestDto);
         inventoryRepository.save(inventory);
-
-        // Redis 재고 초기화
-        redisTemplate.opsForValue().set(STOCK_KEY_PREFIX + inventory.getProductId(), String.valueOf(inventory.getAvailableQuantity()));
-
         return InventoryMapper.entityToDto(inventory);
-    }
-
-    @Transactional
-    public void decreaseInventoryWithLua(UUID productId, int quantity) {
-        String stockKey = STOCK_KEY_PREFIX + productId;
-
-        // Lua Script: 재고 확인 및 차감
-        // 리턴 값: 차감 후 재고 (>=0), -1: 키 없음, -2: 재고 부족
-        String luaScript =
-                "local stock = redis.call('get', KEYS[1]) " +
-                "if not stock then return -1 end " +
-                "if tonumber(stock) < tonumber(ARGV[1]) then return -2 end " +
-                "return redis.call('decrby', KEYS[1], ARGV[1])";
-
-        Long result = redissonClient.getScript()
-                .eval(RScript.Mode.READ_WRITE,
-                        luaScript,
-                        RScript.ReturnType.INTEGER,
-                        Collections.singletonList(stockKey),
-                        quantity);
-
-        if (result == -1) {
-            // Redis에 재고가 없으면 DB에서 로드 후 재시도 (또는 예외 처리)
-            Inventory inventory = inventoryRepository.findByProductIdAndDeletedStatusFalse(productId)
-                    .orElseThrow(InventoryException::forInventoryNotFound);
-            redisTemplate.opsForValue().set(stockKey, String.valueOf(inventory.getAvailableQuantity()));
-            
-            // 로드 후 다시 시도
-            result = redissonClient.getScript()
-                    .eval(RScript.Mode.READ_WRITE,
-                            luaScript,
-                            RScript.ReturnType.INTEGER,
-                            Collections.singletonList(stockKey),
-                            quantity);
-        }
-
-        if (result == -2) {
-            throw InventoryException.forInventoryOutOfStock();
-        }
-
-        if (result == -1) { // 로드 후에도 없으면
-             throw InventoryException.forInventoryNotFound();
-        }
-
-        // DB 재고 업데이트
-        int updated = inventoryRepository.decreaseInventoryAtomically(productId, quantity);
-        if (updated == 0) {
-            throw InventoryException.forInventoryOutOfStock();
-        }
     }
 
     @Transactional(readOnly = true)
@@ -119,6 +62,40 @@ public class InventoryService {
     @DistributedLock(key = "#productId")
     @Transactional
     public void decreaseInventory(UUID productId, int quantity) {
+        int updated = inventoryRepository.decreaseInventoryAtomically(productId, quantity);
+        if (updated == 0) {
+            throw InventoryException.forInventoryOutOfStock();
+        }
+    }
+
+    /**
+     * Lua 스크립트를 사용하여 Redis 재고를 먼저 차감하고 DB를 업데이트합니다.
+     * DB 업데이트 실패 시 Redis 재고를 복구합니다.
+     */
+    public void decreaseInventoryWithLua(UUID productId, int quantity) {
+        Long result = inventoryRedisService.decreaseStock(productId, quantity);
+
+        if (result == -1L) {
+            // Redis에 재고 정보가 없는 경우 DB에서 로드하는 로직이 필요할 수 있으나,
+            // 여기서는 단순하게 예외 처리합니다.
+            throw InventoryException.forInventoryNotFound();
+        }
+        if (result == -2L) {
+            throw InventoryException.forInventoryOutOfStock();
+        }
+
+        try {
+            // DB 업데이트 (트랜잭션 전파를 위해 별도 메서드 호출)
+            decreaseInventoryInternal(productId, quantity);
+        } catch (Exception e) {
+            log.error("[Inventory] DB 업데이트 실패 - Redis 재고 복구 시작: productId={}, quantity={}", productId, quantity, e);
+            inventoryRedisService.increaseStock(productId, quantity);
+            throw e;
+        }
+    }
+
+    @Transactional
+    public void decreaseInventoryInternal(UUID productId, int quantity) {
         int updated = inventoryRepository.decreaseInventoryAtomically(productId, quantity);
         if (updated == 0) {
             throw InventoryException.forInventoryOutOfStock();

--- a/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redis/InventoryRedisService.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redis/InventoryRedisService.java
@@ -2,8 +2,10 @@ package com.live_commerce.product.inventory.infrastructure.redis;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,6 +14,16 @@ import java.util.UUID;
 public class InventoryRedisService {
 
     private final RedisTemplate<String, String>  redisTemplate;
+
+    public Long decreaseStock(UUID productId, int quantity) {
+        String key = RedisKey.availableQuantity(productId);
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>(LuaScripts.STOCK_DECREASE_SCRIPT, Long.class);
+        return redisTemplate.execute(script, Collections.singletonList(key), String.valueOf(quantity));
+    }
+
+    public void increaseStock(UUID productId, int quantity) {
+        redisTemplate.opsForValue().increment(RedisKey.availableQuantity(productId), quantity);
+    }
 
     public void setAvailableQuantity(UUID productId, int quantity) {
         redisTemplate.opsForValue().set(RedisKey.availableQuantity(productId), String.valueOf(quantity));

--- a/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redis/LuaScripts.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/infrastructure/redis/LuaScripts.java
@@ -1,0 +1,9 @@
+package com.live_commerce.product.inventory.infrastructure.redis;
+
+public class LuaScripts {
+    public static final String STOCK_DECREASE_SCRIPT =
+        "local stock = redis.call('get', KEYS[1]) " +
+        "if not stock then return -1 end " +
+        "if tonumber(stock) < tonumber(ARGV[1]) then return -2 end " +
+        "return redis.call('decrby', KEYS[1], ARGV[1])";
+}

--- a/product/src/main/java/com/live_commerce/product/inventory/presentation/controller/InventoryController.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/presentation/controller/InventoryController.java
@@ -44,6 +44,12 @@ public class InventoryController {
         return ResponseUtil.success("재고가 차감되었습니다.");
     }
 
+    @PostMapping("/lua-decrease")
+    public ResponseEntity<ApiResponse<String>> decreaseInventoryWithLua(@Valid @RequestBody InventoryDecreaseRequestDto requestDto) {
+        inventoryService.decreaseInventoryWithLua(requestDto.productId(), requestDto.quantity());
+        return ResponseUtil.success("재고가 차감되었습니다.(lua)");
+    }
+
     @PostMapping("/increase")
     public ResponseEntity<ApiResponse<String>> increaseInventory(@Valid @RequestBody InventoryIncreaseRequestDto requestDto) {
         inventoryService.increaseInventory(requestDto.productId(), requestDto.quantity());

--- a/product/src/main/java/com/live_commerce/product/inventory/presentation/controller/InventoryController.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/presentation/controller/InventoryController.java
@@ -40,7 +40,7 @@ public class InventoryController {
 
     @PostMapping("/decrease")
     public ResponseEntity<ApiResponse<String>> decreaseInventory(@Valid @RequestBody InventoryDecreaseRequestDto requestDto) {
-        inventoryService.decreaseInventory(requestDto.productId(), requestDto.quantity());
+        inventoryService.decreaseInventoryWithLua(requestDto.productId(), requestDto.quantity());
         return ResponseUtil.success("재고가 차감되었습니다.");
     }
 

--- a/product/src/test/java/com/live_commerce/product/inventory/InventoryServiceTest.java
+++ b/product/src/test/java/com/live_commerce/product/inventory/InventoryServiceTest.java
@@ -131,6 +131,42 @@ public class InventoryServiceTest {
 
 
     @Test
+    void Lua_스크립트_동시_재고감소_테스트() throws InterruptedException {
+
+        int threadCount = 10;
+        int decreaseAmountPerThread = 1;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        // 초기 재고 확인 (setUp에서 100으로 설정됨)
+        Inventory beforeInventory = inventoryRepository.findByProductIdAndDeletedStatusFalse(PRODUCT_ID).get();
+        int initialAvailable = beforeInventory.getAvailableQuantity();
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    inventoryService.decreaseInventoryWithLua(PRODUCT_ID, decreaseAmountPerThread);
+                } catch (Exception e) {
+                    System.out.println("예외 발생: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+
+        Inventory inventory = inventoryRepository.findByProductIdAndDeletedStatusFalse(PRODUCT_ID)
+                .orElseThrow(() -> new RuntimeException("재고가 존재하지 않습니다."));
+
+        assertEquals(
+                initialAvailable - (threadCount * decreaseAmountPerThread),
+                inventory.getAvailableQuantity()
+        );
+    }
+
+    @Test
     void 락획득실패_테스트() throws InterruptedException {
         UUID productId = PRODUCT_ID;
 


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 동시성 제어를 위해 Redis Lua Script 기반의 재고 차감 API를 추가

* **세부 내용**
  * 신규 API 추가: POST /api/v1/inventories/lua-decrease 엔드포인트를 추가하여 기존 분산 락 방식 외에 Lua Script 방식을
     선택적으로 사용할 수 있게 했습니다.
  * 데이터 정합성 및 폴백(Fallback):
       * 재고 생성 시 Redis 재고를 자동 초기화합니다.
       * Redis에 재고 데이터가 없을 경우 DB에서 실시간으로 로드하여 동기화하는 로직을 구현했습니다.
       * Redis 차감 성공 시 DB 재고도 함께 업데이트하여 최종 일관성을 유지합니다.

## 💡 추가 설명

* 코드 리뷰 시 특별히 참고해야 할 부분이 있다면 언급해주세요.
* 궁금한 점이나 논의하고 싶은 내용이 있다면 작성해주세요.

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
