### PR TITLE
feat: inventory Outbox 패턴 적용 및 재고 차감 보상 트랜잭션 구현

### DIFF
--- a/product/src/main/java/com/live_commerce/product/ProductApplication.java
+++ b/product/src/main/java/com/live_commerce/product/ProductApplication.java
@@ -3,8 +3,10 @@ package com.live_commerce.product;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableFeignClients
+@EnableScheduling
 @SpringBootApplication
 public class ProductApplication {
 

--- a/product/src/main/java/com/live_commerce/product/inventory/domain/model/InventoryOutbox.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/domain/model/InventoryOutbox.java
@@ -1,0 +1,70 @@
+package com.live_commerce.product.inventory.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "p_inventory_outbox", schema = "inventories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InventoryOutbox {
+
+    @Id
+    @UuidGenerator
+    private UUID id;
+
+    @Column(nullable = false)
+    private UUID orderId;
+
+    @Column(nullable = false)
+    private String eventType;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private InventoryOutboxStatus status;
+
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    private LocalDateTime publishedAt;
+
+    @Column(nullable = false)
+    private int retryCount = 0;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static InventoryOutbox of(UUID orderId, String eventType, String payload) {
+        InventoryOutbox outbox = new InventoryOutbox();
+        outbox.orderId = orderId;
+        outbox.eventType = eventType;
+        outbox.payload = payload;
+        outbox.status = InventoryOutboxStatus.PENDING;
+        outbox.retryCount = 0;
+        return outbox;
+    }
+
+    public void markPublished() {
+        this.status = InventoryOutboxStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now();
+    }
+
+    public void markFailed() {
+        this.status = InventoryOutboxStatus.FAILED;
+    }
+
+    public void incrementRetry() {
+        this.retryCount++;
+    }
+}

--- a/product/src/main/java/com/live_commerce/product/inventory/domain/model/InventoryOutboxStatus.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/domain/model/InventoryOutboxStatus.java
@@ -1,0 +1,5 @@
+package com.live_commerce.product.inventory.domain.model;
+
+public enum InventoryOutboxStatus {
+    PENDING, PUBLISHED, FAILED
+}

--- a/product/src/main/java/com/live_commerce/product/inventory/domain/repository/InventoryOutboxRepository.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/domain/repository/InventoryOutboxRepository.java
@@ -1,0 +1,14 @@
+package com.live_commerce.product.inventory.domain.repository;
+
+import com.live_commerce.product.inventory.domain.model.InventoryOutbox;
+import com.live_commerce.product.inventory.domain.model.InventoryOutboxStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface InventoryOutboxRepository {
+    InventoryOutbox save(InventoryOutbox outbox);
+    List<InventoryOutbox> findTop50ByStatusOrderByCreatedAt(InventoryOutboxStatus status);
+    void updateRecord(UUID id, InventoryOutboxStatus status, LocalDateTime publishedAt, int retryCount);
+}

--- a/product/src/main/java/com/live_commerce/product/inventory/infrastructure/outbox/InventoryOutboxRecordProcessor.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/infrastructure/outbox/InventoryOutboxRecordProcessor.java
@@ -1,0 +1,78 @@
+package com.live_commerce.product.inventory.infrastructure.outbox;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.live_commerce.product.inventory.domain.model.InventoryOutbox;
+import com.live_commerce.product.inventory.domain.repository.InventoryOutboxRepository;
+import com.live_commerce.product.product.infrastructure.kafka.event.InventoryDecreasedEvent;
+import com.live_commerce.product.product.infrastructure.kafka.event.InventoryFailedEvent;
+import com.live_commerce.product.product.infrastructure.kafka.event.InventorySoldOutEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InventoryOutboxRecordProcessor {
+
+    private static final int MAX_RETRY = 3;
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final InventoryOutboxRepository outboxRepository;
+    private final ObjectMapper objectMapper;
+    private final TransactionTemplate transactionTemplate;
+
+    public void process(InventoryOutbox outbox) {
+        try {
+            publish(outbox);
+            outbox.markPublished();
+        } catch (IllegalArgumentException e) {
+            log.error("알 수 없는 이벤트 타입: {}", outbox.getEventType());
+            outbox.markFailed();
+        } catch (Exception e) {
+            log.warn("Outbox 발행 실패 (재시도 예정): id={}, 이유={}", outbox.getId(), e.getMessage());
+            outbox.incrementRetry();
+            if (outbox.getRetryCount() >= MAX_RETRY) {
+                log.error("Outbox 최대 재시도 초과, FAILED 처리: id={}", outbox.getId());
+                outbox.markFailed();
+            }
+        }
+
+        transactionTemplate.executeWithoutResult(tx ->
+                outboxRepository.updateRecord(
+                        outbox.getId(),
+                        outbox.getStatus(),
+                        outbox.getPublishedAt(),
+                        outbox.getRetryCount()
+                )
+        );
+    }
+
+    private void publish(InventoryOutbox outbox) throws Exception {
+        Map<String, Object> map = objectMapper.readValue(outbox.getPayload(), new TypeReference<>() {});
+
+        switch (outbox.getEventType()) {
+            case "INVENTORY_DECREASED" -> {
+                InventoryDecreasedEvent event = objectMapper.convertValue(map, InventoryDecreasedEvent.class);
+                kafkaTemplate.send("inventory-decreased", outbox.getOrderId().toString(), event);
+                log.info("inventory-decreased 발행: orderId={}", outbox.getOrderId());
+            }
+            case "INVENTORY_FAILED" -> {
+                InventoryFailedEvent event = objectMapper.convertValue(map, InventoryFailedEvent.class);
+                kafkaTemplate.send("inventory-failed", outbox.getOrderId().toString(), event);
+                log.info("inventory-failed 발행: orderId={}", outbox.getOrderId());
+            }
+            case "INVENTORY_SOLD_OUT" -> {
+                InventorySoldOutEvent event = objectMapper.convertValue(map, InventorySoldOutEvent.class);
+                kafkaTemplate.send("inventory-sold-out", event.productId().toString(), event);
+                log.info("inventory-sold-out 발행: productId={}", event.productId());
+            }
+            default -> throw new IllegalArgumentException("알 수 없는 이벤트 타입: " + outbox.getEventType());
+        }
+    }
+}

--- a/product/src/main/java/com/live_commerce/product/inventory/infrastructure/outbox/InventoryOutboxRelay.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/infrastructure/outbox/InventoryOutboxRelay.java
@@ -1,0 +1,48 @@
+package com.live_commerce.product.inventory.infrastructure.outbox;
+
+import com.live_commerce.product.inventory.domain.model.InventoryOutbox;
+import com.live_commerce.product.inventory.domain.model.InventoryOutboxStatus;
+import com.live_commerce.product.inventory.domain.repository.InventoryOutboxRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InventoryOutboxRelay {
+
+    private static final String RELAY_LOCK_KEY = "inventory-outbox-relay-lock";
+
+    private final InventoryOutboxRepository outboxRepository;
+    private final InventoryOutboxRecordProcessor recordProcessor;
+    private final RedissonClient redissonClient;
+
+    @Scheduled(fixedDelay = 3000)
+    public void relay() {
+        RLock lock = redissonClient.getLock(RELAY_LOCK_KEY);
+        try {
+            if (!lock.tryLock(0, 2, TimeUnit.MINUTES)) {
+                return;
+            }
+            List<InventoryOutbox> pending = outboxRepository.findTop50ByStatusOrderByCreatedAt(InventoryOutboxStatus.PENDING);
+            if (!pending.isEmpty()) {
+                log.info("Outbox relay 시작: {} 건", pending.size());
+                pending.forEach(recordProcessor::process);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("Outbox relay 인터럽트 발생");
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/product/src/main/java/com/live_commerce/product/inventory/infrastructure/outbox/InventoryTxProcessor.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/infrastructure/outbox/InventoryTxProcessor.java
@@ -1,0 +1,87 @@
+package com.live_commerce.product.inventory.infrastructure.outbox;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.live_commerce.product.inventory.application.validation.InventoryValidator;
+import com.live_commerce.product.inventory.domain.exception.InventoryException;
+import com.live_commerce.product.inventory.domain.model.Inventory;
+import com.live_commerce.product.inventory.domain.model.InventoryOutbox;
+import com.live_commerce.product.inventory.domain.model.InventoryStatus;
+import com.live_commerce.product.inventory.domain.repository.InventoryOutboxRepository;
+import com.live_commerce.product.inventory.domain.repository.InventoryRepository;
+import com.live_commerce.product.product.infrastructure.kafka.event.InventoryDecreasedEvent;
+import com.live_commerce.product.product.infrastructure.kafka.event.InventoryFailedEvent;
+import com.live_commerce.product.product.infrastructure.kafka.event.InventorySoldOutEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InventoryTxProcessor {
+
+    private final InventoryRepository inventoryRepository;
+    private final InventoryOutboxRepository outboxRepository;
+    private final InventoryValidator inventoryValidator;
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 재고 차감 + Outbox 저장을 단일 트랜잭션에서 처리.
+     * 차감 실패 시 예외를 던져 호출부에서 fail()을 호출하도록 함.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void decrease(UUID orderId, UUID productId, int quantity) {
+        int updated = inventoryRepository.decreaseInventoryAtomically(productId, quantity);
+        if (updated == 0) {
+            throw InventoryException.forInventoryOutOfStock();
+        }
+
+        redisTemplate.opsForValue().increment("product:sold_count:" + productId, quantity);
+
+        Inventory inventory = inventoryValidator.validateAndGetActiveInventory(productId);
+        if (inventory.getAvailableQuantity() == 0) {
+            inventory.changeStatus(InventoryStatus.OUT_OF_STOCK);
+            saveOutbox(orderId, "INVENTORY_SOLD_OUT", new InventorySoldOutEvent(productId));
+        }
+
+        saveOutbox(orderId, "INVENTORY_DECREASED", new InventoryDecreasedEvent(orderId, productId, quantity));
+    }
+
+    /**
+     * 재고 차감 실패 이벤트를 Outbox에 저장.
+     * 별도 REQUIRES_NEW 트랜잭션으로 호출부 롤백에 영향받지 않음.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void fail(UUID orderId, UUID productId, int quantity, String message) {
+        saveOutbox(orderId, "INVENTORY_FAILED", new InventoryFailedEvent(orderId, productId, quantity, message));
+    }
+
+    /**
+     * 재고 복구 보상 트랜잭션 (주문 실패 시 호출).
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void compensate(UUID orderId, UUID productId, int quantity) {
+        int updated = inventoryRepository.increaseInventoryAtomically(productId, quantity);
+        if (updated == 0) {
+            log.error("재고 복구 실패 - 대상 없음: orderId={}, productId={}", orderId, productId);
+            throw InventoryException.forInventoryNotFound();
+        }
+        log.info("재고 복구 완료: orderId={}, productId={}, quantity={}", orderId, productId, quantity);
+    }
+
+    private void saveOutbox(UUID orderId, String eventType, Object event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            outboxRepository.save(InventoryOutbox.of(orderId, eventType, payload));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Outbox 직렬화 실패: eventType=" + eventType, e);
+        }
+    }
+}

--- a/product/src/main/java/com/live_commerce/product/inventory/infrastructure/repository/JpaInventoryOutboxRepository.java
+++ b/product/src/main/java/com/live_commerce/product/inventory/infrastructure/repository/JpaInventoryOutboxRepository.java
@@ -1,0 +1,27 @@
+package com.live_commerce.product.inventory.infrastructure.repository;
+
+import com.live_commerce.product.inventory.domain.model.InventoryOutbox;
+import com.live_commerce.product.inventory.domain.model.InventoryOutboxStatus;
+import com.live_commerce.product.inventory.domain.repository.InventoryOutboxRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface JpaInventoryOutboxRepository extends JpaRepository<InventoryOutbox, UUID>, InventoryOutboxRepository {
+
+    List<InventoryOutbox> findTop50ByStatusOrderByCreatedAt(InventoryOutboxStatus status);
+
+    @Modifying
+    @Query("UPDATE InventoryOutbox o SET o.status = :status, o.publishedAt = :publishedAt, o.retryCount = :retryCount WHERE o.id = :id")
+    void updateRecord(
+            @Param("id") UUID id,
+            @Param("status") InventoryOutboxStatus status,
+            @Param("publishedAt") LocalDateTime publishedAt,
+            @Param("retryCount") int retryCount
+    );
+}

--- a/product/src/main/java/com/live_commerce/product/product/infrastructure/kafka/consumer/InventoryEventConsumer.java
+++ b/product/src/main/java/com/live_commerce/product/product/infrastructure/kafka/consumer/InventoryEventConsumer.java
@@ -1,14 +1,12 @@
 package com.live_commerce.product.product.infrastructure.kafka.consumer;
 
-import com.live_commerce.product.inventory.application.service.InventoryService;
 import com.live_commerce.product.inventory.domain.exception.InventoryException;
-import com.live_commerce.product.product.infrastructure.kafka.event.InventoryDecreasedEvent;
+import com.live_commerce.product.inventory.infrastructure.outbox.InventoryTxProcessor;
 import com.live_commerce.product.product.infrastructure.kafka.event.InventoryRollbackEvent;
 import com.live_commerce.product.product.infrastructure.kafka.event.OrderRequestedInventoryEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -16,50 +14,27 @@ import org.springframework.stereotype.Service;
 @Service
 public class InventoryEventConsumer {
 
-    private final InventoryService inventoryService;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final InventoryTxProcessor inventoryTxProcessor;
 
     @KafkaListener(topics = "inventory-decrease", concurrency = "4", containerFactory = "kafkaListenerContainerFactory")
     public void consumeOrderCreated(OrderRequestedInventoryEvent event) {
         log.info("inventory-decrease 이벤트 수신: {}", event);
-
         try {
-            inventoryService.decreaseInventoryV2(event.productId(), event.quantity());
-
-            InventoryDecreasedEvent decreasedEvent = new InventoryDecreasedEvent(
-                    event.orderId(),
-                    event.productId(),
-                    event.quantity()
-            );
-            kafkaTemplate.send("inventory-decreased", event.productId().toString(), decreasedEvent);
-            log.info("inventory-decreased 이벤트 발행 완료: {}", decreasedEvent);
+            inventoryTxProcessor.decrease(event.orderId(), event.productId(), event.quantity());
+            log.info("재고 차감 완료: orderId={}", event.orderId());
         } catch (InventoryException e) {
-            log.error("재고 차감 실패: {}, 이유: {}", event.orderId(), e.getMessage());
-
-//            InventoryFailedEvent failedEvent = new InventoryFailedEvent(
-//                    event.orderId(),
-//                    event.productId(),
-//                    event.quantity(),
-//                    e.getMessage()
-//            );
-//            kafkaTemplate.send("inventory-failed", failedEvent);
-//            log.info("inventory-failed 이벤트 발행 완료: {}", failedEvent);
+            log.error("재고 차감 실패: orderId={}, 이유={}", event.orderId(), e.getMessage());
+            inventoryTxProcessor.fail(event.orderId(), event.productId(), event.quantity(), e.getMessage());
         }
     }
 
     @KafkaListener(topics = "inventory-rollback")
     public void consumeInventoryRollback(InventoryRollbackEvent event) {
         log.info("inventory-rollback 이벤트 수신: {}", event);
-
         try {
-            inventoryService.increaseInventoryV2(event.productId(), event.quantity());
-
-            log.info("재고 복구 완료 - productId: {}, quantity: {}", event.productId(), event.quantity());
+            inventoryTxProcessor.compensate(event.orderId(), event.productId(), event.quantity());
         } catch (Exception e) {
-            log.error("재고 복구 실패 - productId: {}, 이유: {}", event.productId(), e.getMessage());
-            // 필요시 실패 이벤트 발행 고려 중
+            log.error("재고 복구 실패 - 수동 조치 필요: orderId={}, productId={}, 이유={}", event.orderId(), event.productId(), e.getMessage());
         }
     }
-
-
 }


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [ ] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [x] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 PR 내용
* **한 줄 요약**
  * 재고 차감 이벤트의 유실 가능성을 제거하고, 차감 실패 시 상위 서비스(Order)가 보상 처리를 할 수 있도록 inventory-failed 이벤트를 신뢰성 있게 발행하는 Outbox 패턴을 도입했습니다.

* **세부 내용**
  * 문제상황 : 기존 InventoryEventConsumer는 재고 차감 성공 시 Kafka 이벤트를 직접 발행했습니다. DB 커밋과 Kafka 발행 사이에 서비스가 크래시되면 이벤트가 유실될 위험이 있었고, 차감 실패 시에는 inventory-failed 발행 코드가 주석 처리된 채로   
  방치돼 있어 Order 서비스가 보상 처리를 시작할 수 없었습니다.
  * 변경사항
  * Outbox 도메인 (신규)
    - InventoryOutbox — inventories.p_inventory_outbox 테이블에 매핑되는 JPA 엔티티
    - InventoryOutboxStatus — PENDING / PUBLISHED / FAILED 상태 관리
    - InventoryOutboxRepository / JpaInventoryOutboxRepository — 레포지토리 인터페이스 및 구현
  * Outbox 처리 로직 (신규)
    - InventoryTxProcessor — 재고 DB 변경과 Outbox 저장을 REQUIRES_NEW 단일 트랜잭션으로 묶어 원자성 보장
      - decrease() — 차감 성공 시 INVENTORY_DECREASED Outbox 저장
      - fail() — 차감 실패 시 INVENTORY_FAILED Outbox 저장 (별도 트랜잭션, 롤백 영향 없음)
      - compensate() — inventory-rollback 수신 시 재고 복구
    - InventoryOutboxRecordProcessor — Outbox 레코드 1건을 Kafka로 발행, 최대 3회 재시도 후 FAILED 처리
    - InventoryOutboxRelay — 3초마다 PENDING 레코드를 조회해 릴레이 (Redisson 분산 락으로 중복 실행 방지)
  * 기존 코드 변경
    - InventoryEventConsumer — InventoryTxProcessor 사용으로 교체, 실패 분기 정상화
    - ProductApplication — @EnableScheduling 추가
  * 이벤트 흐름
    ```
        [차감 성공]
        inventory-decrease 수신 → TxProcessor.decrease() → DB 차감 + Outbox(INVENTORY_DECREASED) 저장
                                                     └→ Relay가 Kafka inventory-decreased 발행
        [차감 실패]
        inventory-decrease 수신 → TxProcessor.fail() → Outbox(INVENTORY_FAILED) 저장
                                                 └→ Relay가 Kafka inventory-failed 발행
                                                    → Order 서비스가 주문 실패 처리 시작
        [보상 트랜잭션]
        inventory-rollback 수신 → TxProcessor.compensate() → DB 재고 복구
    ```


## 💡 추가 설명

  - DB에 inventories.p_inventory_outbox 테이블 생성 필요 (ddl-auto가 create/update면 자동 생성)
  - Payment 서비스의 PaymentTxProcessor / PaymentOutbox 구조를 참고해 일관성 있게 설계

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
