### PR TITLE
Feature/pdsh 9 gemini api stability

### DIFF
--- a/ai/build.gradle
+++ b/ai/build.gradle
@@ -80,6 +80,10 @@ dependencies {
 	// webflux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+	// retry
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	// H2 DB
 	testRuntimeOnly 'com.h2database:h2'
 

--- a/ai/src/main/java/com/live_commerce/ai/AiApplication.java
+++ b/ai/src/main/java/com/live_commerce/ai/AiApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
 @EnableFeignClients
 @EnableJpaAuditing
+@EnableRetry
 public class AiApplication {
 
 	public static void main(String[] args) {

--- a/ai/src/main/java/com/live_commerce/ai/application/dto/response/GeminiResponseDto.java
+++ b/ai/src/main/java/com/live_commerce/ai/application/dto/response/GeminiResponseDto.java
@@ -6,6 +6,7 @@ public record GeminiResponseDto(List<Candidate> candidates) {
 	public String extractText() {
 		if (candidates == null || candidates.isEmpty()) return "";
 		Content content = candidates.get(0).content();
+		if (content == null) return "";
 		List<Content.Part> parts = content.parts();
 		return (parts != null && !parts.isEmpty()) ? parts.get(0).text() : "";
 	}

--- a/ai/src/main/java/com/live_commerce/ai/infrastructure/client/GeminiFeignClient.java
+++ b/ai/src/main/java/com/live_commerce/ai/infrastructure/client/GeminiFeignClient.java
@@ -4,7 +4,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 import com.live_commerce.ai.application.dto.request.GeminiRequestDto;
 import com.live_commerce.ai.application.dto.response.GeminiResponseDto;
@@ -18,7 +18,7 @@ public interface GeminiFeignClient {
 	@PostMapping("/{model}:generateContent")
 	GeminiResponseDto getCompletion(
 		@PathVariable("model") String model,
-		@RequestParam("key") String key,
+		@RequestHeader("x-goog-api-key") String key,
 		@RequestBody GeminiRequestDto geminiRequestDto
 	);
 }

--- a/ai/src/main/java/com/live_commerce/ai/infrastructure/client/GeminiServiceAdapter.java
+++ b/ai/src/main/java/com/live_commerce/ai/infrastructure/client/GeminiServiceAdapter.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
@@ -12,7 +13,9 @@ import com.live_commerce.ai.application.dto.response.GeminiResponseDto;
 
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class GeminiServiceAdapter {
@@ -38,6 +41,17 @@ public class GeminiServiceAdapter {
 		);
 
 		GeminiResponseDto responseDto = geminiFeignClient.getCompletion(modelName, apiKey, requestDto);
-		return responseDto.extractText();
+		String text = responseDto.extractText();
+		if (text.isEmpty()) {
+			log.warn("[Gemini] 응답 본문이 비어있음: model={}", modelName);
+		}
+		return text;
+	}
+
+	// 재시도 소진 후 호출 — 로그 남기고 rethrow, AiService가 CustomException으로 변환
+	@Recover
+	public String recoverGenerateText(FeignException e, String prompt) {
+		log.warn("[Gemini] 재시도 소진 - API 호출 실패: status={}, message={}", e.status(), e.getMessage());
+		throw e;
 	}
 }

--- a/ai/src/main/java/com/live_commerce/ai/infrastructure/client/GeminiServiceAdapter.java
+++ b/ai/src/main/java/com/live_commerce/ai/infrastructure/client/GeminiServiceAdapter.java
@@ -3,11 +3,14 @@ package com.live_commerce.ai.infrastructure.client;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
 import com.live_commerce.ai.application.dto.request.GeminiRequestDto;
 import com.live_commerce.ai.application.dto.response.GeminiResponseDto;
 
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -22,6 +25,11 @@ public class GeminiServiceAdapter {
 	@Value("${gemini.model.name}")
 	private String modelName;
 
+	@Retryable(
+		retryFor = { FeignException.TooManyRequests.class, FeignException.ServiceUnavailable.class },
+		maxAttempts = 3,
+		backoff = @Backoff(delay = 1000, multiplier = 2)
+	)
 	public String generateText(String prompt) {
 		GeminiRequestDto requestDto = new GeminiRequestDto(
 			List.of(new GeminiRequestDto.Content(

--- a/ai/src/main/resources/application.yml
+++ b/ai/src/main/resources/application.yml
@@ -6,6 +6,13 @@ spring:
   profiles:
     active: dev
 
+feign:
+  client:
+    config:
+      geminiClient:
+        connectTimeout: 3000
+        readTimeout: 30000
+
 #spring:
 #  profiles:
 #    active: prod


### PR DESCRIPTION
  ## ✨ 변경 타입

  - [x] 신규 기능 추가/수정
  - [x] 버그 수정
  - [ ] 리팩토링
  - [x] 설정
  - [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

  ## ✅ 체크리스트

  - [x] 코드 작성 가이드라인을 준수했는가?
  - [ ] 변경 사항에 대한 테스트를 완료했는가?
  - [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

  ## 🚀 PR 내용

  - 한 줄 요약
      - Gemini API 호출 안정성을 높이기 위해 인증 헤더 처리, 응답 방어 로직, 재시도, 타임아웃 설정을 적용했습니다.
  - 세부 내용
      - Gemini API 키 전달 방식을 쿼리 파라미터에서 x-goog-api-key 헤더로 변경했습니다.
      - Gemini 응답의 content가 null인 경우를 방어하도록 null 체크를 추가했습니다.
      - 429 Too Many Requests, 503 Service Unavailable 응답에 대해 최대 3회 재시도하도록 Spring Retry를 적용했습니다.
      - Gemini Feign 클라이언트에 connectTimeout=3000, readTimeout=30000 설정을 추가했습니다.
      - 재시도 기능 활성화를 위해 spring-retry, spring-boot-starter-aop 의존성과 @EnableRetry를 추가했습니다.

  ## 💡 추가 설명

  - 코드 리뷰 시 특별히 참고해야 할 부분이 있다면 언급해주세요.
      - 재시도 대상 예외를 FeignException.TooManyRequests, FeignException.ServiceUnavailable로 한정했습니다. 실제 운영에서 추가로 재시도가 필요한 케이스가 있는지 확인
        부탁드립니다.
      - API 키를 헤더로 변경한 부분이 Gemini 호출 정책과 배포 환경 설정에 맞는지 함께 봐주시면 됩니다.
  - 궁금한 점이나 논의하고 싶은 내용이 있다면 작성해주세요.
      - 현재 브랜치 기준으로는 별도 테스트 코드 추가나 테스트 실행 이력은 확인되지 않아 체크리스트의 테스트 항목은 비워두는 편이 맞습니다.

  ## 📚 참고 자료 (선택 사항)

  - 관련 자료 링크
      - Google Gemini API 문서
      - Spring Retry 문서
